### PR TITLE
Fix HTTP verbs

### DIFF
--- a/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
@@ -66,7 +66,7 @@ public class ConsulClientImpl implements ConsulClient {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<ClientResponse> reference = new AtomicReference<>();
 		try {
-			ClientRequest request = new ClientRequest().setMethod(Methods.GET).setPath(path);
+			ClientRequest request = new ClientRequest().setMethod(Methods.PUT).setPath(path);
 			request.getRequestHeaders().put(Headers.HOST, "localhost");
 			if(token != null) request.getRequestHeaders().put(Constants.CONSUL_TOKEN, token);
 			connection.sendRequest(request, client.createClientCallback(reference, latch));
@@ -97,7 +97,7 @@ public class ConsulClientImpl implements ConsulClient {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<ClientResponse> reference = new AtomicReference<>();
 		try {
-			ClientRequest request = new ClientRequest().setMethod(Methods.GET).setPath(path);
+			ClientRequest request = new ClientRequest().setMethod(Methods.PUT).setPath(path);
 			request.getRequestHeaders().put(Headers.HOST, "localhost");
 			if(token != null) request.getRequestHeaders().put(Constants.CONSUL_TOKEN, token);
 			connection.sendRequest(request, client.createClientCallback(reference, latch));
@@ -156,7 +156,7 @@ public class ConsulClientImpl implements ConsulClient {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<ClientResponse> reference = new AtomicReference<>();
 		try {
-			ClientRequest request = new ClientRequest().setMethod(Methods.GET).setPath(path);
+			ClientRequest request = new ClientRequest().setMethod(Methods.PUT).setPath(path);
             request.getRequestHeaders().put(Headers.HOST, "localhost");
 			if(token != null) request.getRequestHeaders().put(Constants.CONSUL_TOKEN, token);
 			connection.sendRequest(request, client.createClientCallback(reference, latch));


### PR DESCRIPTION
Consul 1.0.0 started enforcing HTTP verbs in many endpoints. GET methods must be changed to PUT.
See: https://github.com/hashicorp/consul/blob/v1.0.0/CHANGELOG.md