### PR TITLE
fixes #279 Consul heartbeat stream limit being exceeded

### DIFF
--- a/consul/src/main/java/com/networknt/consul/ConsulConfig.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulConfig.java
@@ -2,6 +2,7 @@ package com.networknt.consul;
 
 public class ConsulConfig {
     String consulUrl;
+    int maxReqPerConn;
     String deregisterAfter;
     String checkInterval;
     boolean tcpCheck;
@@ -15,6 +16,10 @@ public class ConsulConfig {
     public void setConsulUrl(String consulUrl) {
         this.consulUrl = consulUrl;
     }
+
+    public int getMaxReqPerConn() { return maxReqPerConn; }
+
+    public void setMaxReqPerConn(int maxReqPerConn) { this.maxReqPerConn = maxReqPerConn; }
 
     public String getDeregisterAfter() {
         return deregisterAfter;

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
@@ -73,7 +73,7 @@ public class ConsulClientImpl implements ConsulClient {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<ClientResponse> reference = new AtomicReference<>();
 		try {
-			if(connection == null || !connection.isOpen() || reqCounter > maxReqPerConn) {
+			if(connection == null || !connection.isOpen() || reqCounter >= maxReqPerConn) {
 				if(logger.isDebugEnabled()) logger.debug("connection is closed with counter " + reqCounter + ", reconnecting...");
 				connection = client.connect(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.POOL, optionMap).get();
 				reqCounter = 0;
@@ -101,7 +101,7 @@ public class ConsulClientImpl implements ConsulClient {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<ClientResponse> reference = new AtomicReference<>();
 		try {
-			if(connection == null || !connection.isOpen() || reqCounter > maxReqPerConn) {
+			if(connection == null || !connection.isOpen() || reqCounter >= maxReqPerConn) {
 				if(logger.isDebugEnabled()) logger.debug("connection is closed with counter " + reqCounter + ", reconnecting...");
 				connection = client.connect(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.POOL, optionMap).get();
 				reqCounter = 0;
@@ -129,7 +129,7 @@ public class ConsulClientImpl implements ConsulClient {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<ClientResponse> reference = new AtomicReference<>();
 		try {
-			if(connection == null || !connection.isOpen() || reqCounter > maxReqPerConn) {
+			if(connection == null || !connection.isOpen() || reqCounter >= maxReqPerConn) {
 				if(logger.isDebugEnabled()) logger.debug("connection is closed with counter " + reqCounter + ", reconnecting...");
 				connection = client.connect(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.POOL, optionMap).get();
 				reqCounter = 0;
@@ -156,7 +156,7 @@ public class ConsulClientImpl implements ConsulClient {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<ClientResponse> reference = new AtomicReference<>();
 		try {
-			if(connection == null || !connection.isOpen() || reqCounter > maxReqPerConn) {
+			if(connection == null || !connection.isOpen() || reqCounter >= maxReqPerConn) {
 				if(logger.isDebugEnabled()) logger.debug("connection is closed with counter " + reqCounter + ", reconnecting...");
 				connection = client.connect(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.POOL, optionMap).get();
 				reqCounter = 0;
@@ -190,7 +190,7 @@ public class ConsulClientImpl implements ConsulClient {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<ClientResponse> reference = new AtomicReference<>();
 		try {
-			if(connection == null || !connection.isOpen() || reqCounter > maxReqPerConn) {
+			if(connection == null || !connection.isOpen() || reqCounter >= maxReqPerConn) {
 				if(logger.isDebugEnabled()) logger.debug("connection is closed with counter " + reqCounter + ", reconnecting...");
 				connection = client.connect(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.POOL, optionMap).get();
 				reqCounter = 0;

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
@@ -45,7 +45,8 @@ public class ConsulClientImpl implements ConsulClient {
 	ClientConnection connection;
 	OptionMap optionMap;
 	URI uri;
-
+	int maxReqPerConn;
+	int reqCounter = 0;
 	/**
 	 * Construct ConsulClient with all parameters from consul.yml config file. The other two constructors are
 	 * just for backward compatibility.
@@ -62,6 +63,7 @@ public class ConsulClientImpl implements ConsulClient {
 			logger.error("Invalid URI " + consulUrl, e);
 			throw new RuntimeException("Invalid URI " + consulUrl, e);
 		}
+		maxReqPerConn = config.getMaxReqPerConn() > 0 ? config.getMaxReqPerConn() : 1000000;
 	}
 
 	@Override
@@ -71,15 +73,17 @@ public class ConsulClientImpl implements ConsulClient {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<ClientResponse> reference = new AtomicReference<>();
 		try {
-			if(connection == null || !connection.isOpen()) {
-				if(logger.isDebugEnabled()) logger.debug("connection is closed somehow, reconnecting...");
+			if(connection == null || !connection.isOpen() || reqCounter > maxReqPerConn) {
+				if(logger.isDebugEnabled()) logger.debug("connection is closed with counter " + reqCounter + ", reconnecting...");
 				connection = client.connect(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.POOL, optionMap).get();
+				reqCounter = 0;
 			}
 			ClientRequest request = new ClientRequest().setMethod(Methods.PUT).setPath(path);
 			request.getRequestHeaders().put(Headers.HOST, "localhost");
 			if(token != null) request.getRequestHeaders().put(HttpStringConstants.CONSUL_TOKEN, token);
 			connection.sendRequest(request, client.createClientCallback(reference, latch));
 			latch.await();
+			reqCounter++;
 			int statusCode = reference.get().getResponseCode();
 			if(statusCode >= 300){
 				logger.error("Failed to checkPass on Consul: " + statusCode + ":" + reference.get().getAttachment(Http2Client.RESPONSE_BODY));
@@ -97,15 +101,17 @@ public class ConsulClientImpl implements ConsulClient {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<ClientResponse> reference = new AtomicReference<>();
 		try {
-			if(connection == null || !connection.isOpen()) {
-				if(logger.isDebugEnabled()) logger.debug("connection is closed somehow, reconnecting...");
+			if(connection == null || !connection.isOpen() || reqCounter > maxReqPerConn) {
+				if(logger.isDebugEnabled()) logger.debug("connection is closed with counter " + reqCounter + ", reconnecting...");
 				connection = client.connect(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.POOL, optionMap).get();
+				reqCounter = 0;
 			}
 			ClientRequest request = new ClientRequest().setMethod(Methods.PUT).setPath(path);
 			request.getRequestHeaders().put(Headers.HOST, "localhost");
 			if(token != null) request.getRequestHeaders().put(HttpStringConstants.CONSUL_TOKEN, token);
 			connection.sendRequest(request, client.createClientCallback(reference, latch));
 			latch.await();
+			reqCounter++;
 			int statusCode = reference.get().getResponseCode();
 			if(statusCode >= 300){
 				logger.error("Failed to checkPass on Consul: " + statusCode + ":" + reference.get().getAttachment(Http2Client.RESPONSE_BODY));
@@ -123,9 +129,10 @@ public class ConsulClientImpl implements ConsulClient {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<ClientResponse> reference = new AtomicReference<>();
 		try {
-			if(connection == null || !connection.isOpen()) {
-				if(logger.isDebugEnabled()) logger.debug("connection is closed somehow, reconnecting...");
+			if(connection == null || !connection.isOpen() || reqCounter > maxReqPerConn) {
+				if(logger.isDebugEnabled()) logger.debug("connection is closed with counter " + reqCounter + ", reconnecting...");
 				connection = client.connect(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.POOL, optionMap).get();
+				reqCounter = 0;
 			}
 			ClientRequest request = new ClientRequest().setMethod(Methods.PUT).setPath(path);
 			if(token != null) request.getRequestHeaders().put(HttpStringConstants.CONSUL_TOKEN, token);
@@ -133,6 +140,7 @@ public class ConsulClientImpl implements ConsulClient {
 			request.getRequestHeaders().put(Headers.TRANSFER_ENCODING, "chunked");
 			connection.sendRequest(request, client.createClientCallback(reference, latch, json));
 			latch.await();
+			reqCounter++;
 			int statusCode = reference.get().getResponseCode();
 			if(statusCode >= 300){
 				throw new Exception("Failed to register on Consul: " + statusCode);
@@ -148,9 +156,10 @@ public class ConsulClientImpl implements ConsulClient {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<ClientResponse> reference = new AtomicReference<>();
 		try {
-			if(connection == null || !connection.isOpen()) {
-				if(logger.isDebugEnabled()) logger.debug("connection is closed somehow, reconnecting...");
+			if(connection == null || !connection.isOpen() || reqCounter > maxReqPerConn) {
+				if(logger.isDebugEnabled()) logger.debug("connection is closed with counter " + reqCounter + ", reconnecting...");
 				connection = client.connect(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.POOL, optionMap).get();
+				reqCounter = 0;
 			}
 
 			ClientRequest request = new ClientRequest().setMethod(Methods.PUT).setPath(path);
@@ -158,6 +167,7 @@ public class ConsulClientImpl implements ConsulClient {
 			if(token != null) request.getRequestHeaders().put(HttpStringConstants.CONSUL_TOKEN, token);
 			connection.sendRequest(request, client.createClientCallback(reference, latch));
 			latch.await();
+			reqCounter++;
 			int statusCode = reference.get().getResponseCode();
 			if(statusCode >= 300){
 				System.out.println("body = " + reference.get().getAttachment(Http2Client.RESPONSE_BODY));
@@ -180,15 +190,17 @@ public class ConsulClientImpl implements ConsulClient {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<ClientResponse> reference = new AtomicReference<>();
 		try {
-			if(connection == null || !connection.isOpen()) {
-				if(logger.isDebugEnabled()) logger.debug("connection is closed somehow, reconnecting...");
+			if(connection == null || !connection.isOpen() || reqCounter > maxReqPerConn) {
+				if(logger.isDebugEnabled()) logger.debug("connection is closed with counter " + reqCounter + ", reconnecting...");
 				connection = client.connect(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.POOL, optionMap).get();
+				reqCounter = 0;
 			}
 			ClientRequest request = new ClientRequest().setMethod(Methods.GET).setPath(path);
 			if(token != null) request.getRequestHeaders().put(HttpStringConstants.CONSUL_TOKEN, token);
 			request.getRequestHeaders().put(Headers.HOST, "localhost");
 			connection.sendRequest(request, client.createClientCallback(reference, latch));
 			latch.await();
+			reqCounter++;
 			int statusCode = reference.get().getResponseCode();
 			if(statusCode >= 300){
 				if(logger.isDebugEnabled()) logger.debug("body = " + reference.get().getAttachment(Http2Client.RESPONSE_BODY));

--- a/consul/src/main/resources/config/consul.yml
+++ b/consul/src/main/resources/config/consul.yml
@@ -1,5 +1,7 @@
 # Consul URL for accessing APIs
 consulUrl: https://localhost:8500
+# number of requests before reset the shared connection.
+maxReqPerConn: 1000000
 # deregister the service after the amount of time after health check failed.
 deregisterAfter: 2m
 # health check interval for TCP or HTTP check. Or it will be the TTL for TTL check. Every 10 seconds,


### PR DESCRIPTION
make a number of requests configurable in consul.yml and reset the connection if the max number is exceeded. 