### PR TITLE
Related to #249, adds an EndpointSource interface for injecting path,…

### DIFF
--- a/handler/src/main/java/com/networknt/handler/Handler.java
+++ b/handler/src/main/java/com/networknt/handler/Handler.java
@@ -49,7 +49,7 @@ public class Handler {
 //		initPaths();
 //	}
 
-	public static void init() throws Exception {
+	public static void init() {
 		initHandlers();
 		initChains();
 		initPaths();		
@@ -100,7 +100,7 @@ public class Handler {
 	/**
 	 * Build "handlerListById" and "reqTypeMatcherMap" from the paths in the config.
 	 */
-	static void initPaths() throws Exception {
+	static void initPaths() {
 		if (config != null && config.getPaths() != null) {
 			for (PathChain pathChain : config.getPaths()) {
 				pathChain.validate(configName + " config"); // raises exception on misconfiguration
@@ -116,7 +116,7 @@ public class Handler {
 	/**
 	 * Add PathChains crated from the EndpointSource given in sourceChain
 	 */
-	private static void addSourceChain(PathChain sourceChain) throws Exception {
+	private static void addSourceChain(PathChain sourceChain) {
 		try {
 			Class sourceClass = Class.forName(sourceChain.getSource());
 			EndpointSource source = (EndpointSource)sourceClass.newInstance();
@@ -130,7 +130,11 @@ public class Handler {
 			}
 		} catch (Exception e) {
 			logger.error("Failed to inject handler.yml paths from: " + sourceChain);
-			throw e;
+			if(e instanceof RuntimeException) {
+				throw (RuntimeException)e;
+			} else {
+				throw new RuntimeException(e);
+			}
 		}
 	}
 

--- a/handler/src/main/java/com/networknt/handler/Handler.java
+++ b/handler/src/main/java/com/networknt/handler/Handler.java
@@ -2,6 +2,7 @@ package com.networknt.handler;
 
 import com.networknt.utility.Tuple;
 import com.networknt.config.Config;
+import com.networknt.handler.config.EndpointSource;
 import com.networknt.handler.config.HandlerConfig;
 import com.networknt.handler.config.PathChain;
 import com.networknt.service.ServiceUtil;
@@ -31,6 +32,8 @@ public class Handler {
 	private static final AttachmentKey<String> CHAIN_ID = AttachmentKey.create(String.class);
 	private static final Logger logger = LoggerFactory.getLogger(Handler.class);
 	private static final String CONFIG_NAME = "handler";
+	private static String configName = CONFIG_NAME;
+
 	// Accessed directly.
 	public static HandlerConfig config = (HandlerConfig) Config.getInstance().getJsonObjectConfig(CONFIG_NAME,
 			HandlerConfig.class);
@@ -46,7 +49,7 @@ public class Handler {
 //		initPaths();
 //	}
 
-	public static void init() {
+	public static void init() throws Exception {
 		initHandlers();
 		initChains();
 		initPaths();		
@@ -97,35 +100,67 @@ public class Handler {
 	/**
 	 * Build "handlerListById" and "reqTypeMatcherMap" from the paths in the config.
 	 */
-	static void initPaths() {
+	static void initPaths() throws Exception {
 		if (config != null && config.getPaths() != null) {
 			for (PathChain pathChain : config.getPaths()) {
-				HttpString method = new HttpString(pathChain.getMethod());
-
-				// Use a random integer as the id for a given path.
-				Integer randInt = new Random().nextInt();
-				while (handlerListById.containsKey(randInt.toString())) {
-					randInt = new Random().nextInt();
-				}
-
-				// Flatten out the execution list from a mix of middleware chains and handlers.
-				List<HttpHandler> handlers = getHandlersFromExecList(pathChain.getExec());
-				if (handlers.size() > 0) {
-					// If a matcher already exists for the given type, at to that instead of
-					// creating a new one.
-					PathTemplateMatcher<String> pathTemplateMatcher = methodToMatcherMap.containsKey(method)
-							? methodToMatcherMap.get(method)
-							: new PathTemplateMatcher<>();
-							
-					if(pathTemplateMatcher.get(pathChain.getPath()) == null)
-						pathTemplateMatcher.add(pathChain.getPath(), randInt.toString());
-					methodToMatcherMap.put(method, pathTemplateMatcher);
-					handlerListById.put(randInt.toString(), handlers);
+				pathChain.validate(configName + " config"); // raises exception on misconfiguration
+				if(pathChain.getPath() == null) {
+					addSourceChain(pathChain);
+				} else {
+					addPathChain(pathChain);
 				}
 			}
 		}
 	}
-	
+
+	/**
+	 * Add PathChains crated from the EndpointSource given in sourceChain
+	 */
+	private static void addSourceChain(PathChain sourceChain) throws Exception {
+		try {
+			Class sourceClass = Class.forName(sourceChain.getSource());
+			EndpointSource source = (EndpointSource)sourceClass.newInstance();
+			for (EndpointSource.Endpoint endpoint : source.listEndpoints()) {
+				PathChain sourcedPath = new PathChain();
+				sourcedPath.setPath(endpoint.getPath());
+				sourcedPath.setMethod(endpoint.getMethod());
+				sourcedPath.setExec(sourceChain.getExec());
+				sourcedPath.validate(sourceChain.getSource());
+				addPathChain(sourcedPath);
+			}
+		} catch (Exception e) {
+			logger.error("Failed to inject handler.yml paths from: " + sourceChain);
+			throw e;
+		}
+	}
+
+	/**
+	 * Add a PathChain (having a non-null path) to the handler data structures.
+	 */
+	private static void addPathChain(PathChain pathChain) {
+		HttpString method = new HttpString(pathChain.getMethod());
+
+		// Use a random integer as the id for a given path.
+		Integer randInt = new Random().nextInt();
+		while (handlerListById.containsKey(randInt.toString())) {
+			randInt = new Random().nextInt();
+		}
+
+		// Flatten out the execution list from a mix of middleware chains and handlers.
+		List<HttpHandler> handlers = getHandlersFromExecList(pathChain.getExec());
+		if(handlers.size() > 0) {
+			// If a matcher already exists for the given type, at to that instead of
+			// creating a new one.
+			PathTemplateMatcher<String> pathTemplateMatcher = methodToMatcherMap.containsKey(method)
+				? methodToMatcherMap.get(method)
+				: new PathTemplateMatcher<>();
+
+			if(pathTemplateMatcher.get(pathChain.getPath()) == null) { pathTemplateMatcher.add(pathChain.getPath(), randInt.toString()); }
+			methodToMatcherMap.put(method, pathTemplateMatcher);
+			handlerListById.put(randInt.toString(), handlers);
+		}
+	}
+
 	/**
 	 * Handle the next request in the chain.
 	 *
@@ -406,6 +441,7 @@ public class Handler {
 
 	// Exposed for testing only.
 	static void setConfig(String configName) throws Exception {
+		Handler.configName = configName;
 		config = (HandlerConfig) Config.getInstance().getJsonObjectConfig(configName, HandlerConfig.class);
 		initHandlers();
 		initPaths();

--- a/handler/src/main/java/com/networknt/handler/config/EndpointSource.java
+++ b/handler/src/main/java/com/networknt/handler/config/EndpointSource.java
@@ -1,0 +1,44 @@
+package com.networknt.handler.config;
+
+import java.util.Objects;
+
+/**
+ * Interface for generating a sequence of path/method pairs for injecting into handler.yml
+ */
+public interface EndpointSource {
+
+    final class Endpoint {
+
+        private String path;
+        private String method;
+
+        public Endpoint(String path, String method) {
+            this.path = path;
+            this.method = method;
+        }
+
+        public String getPath() { return path; }
+
+        public String getMethod() { return method; }
+
+        @Override
+        public String toString() {
+            return path + "@" + method;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if(this == o) return true;
+            if(o == null || getClass() != o.getClass()) return false;
+            Endpoint endpoint = (Endpoint)o;
+            return Objects.equals(path, endpoint.path) &&
+                Objects.equals(method, endpoint.method);
+        }
+
+        @Override
+        public int hashCode() { return Objects.hash(path, method); }
+    }
+
+    Iterable<Endpoint> listEndpoints();
+
+}

--- a/handler/src/main/java/com/networknt/handler/config/PathChain.java
+++ b/handler/src/main/java/com/networknt/handler/config/PathChain.java
@@ -2,15 +2,22 @@ package com.networknt.handler.config;
 
 import com.networknt.utility.NetUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * @author Nicholas Azar
  */
 public class PathChain {
+
+    private String source;
     private String path;
     private String method;
     private List<String> exec;
+
+    public String getSource() { return source; }
+
+    public void setSource(String source) { this.source = source; }
 
     public String getPath() {
         return path;
@@ -32,11 +39,37 @@ public class PathChain {
         return method;
     }
 
-    public void setMethod(String method) throws Exception {
-        if (NetUtils.METHODS.contains(method.toUpperCase())) {
-            this.method = method;
+    public void setMethod(String method) { this.method = method; }
+
+    @Override
+    public String toString() {
+        if(path != null) {
+            return path + "@" + method + " → " + exec;
         } else {
-            throw new Exception("Invalid HTTP method provided: " + method);
+            return source + "() → " + exec;
+        }
+    }
+    /**
+     * Validate the settings and raise Exception on error.
+     * The origin is used to help locate problems.
+     */
+    public void validate(String origin) throws Exception {
+        List<String> problems = new ArrayList<>();
+        if(source == null) {
+            if(path == null) {
+                problems.add("You must specify either path or source");
+            } else if(method == null) {
+                problems.add("You must specify method along with path: " + path);
+            }
+        } else {
+            if(path != null) problems.add("Conflicting source: " + source + " and path: " + path);
+            if(path != null) problems.add("Conflicting source: " + source + " and method: " + method);
+        }
+        if(method != null && !NetUtils.METHODS.contains(method.toUpperCase())) {
+            problems.add("Invalid HTTP method: " + method);
+        }
+        if(!problems.isEmpty()) {
+            throw new Exception("Bad paths element in " + origin + " [ " + String.join(" | ", problems) + " ]");
         }
     }
 }

--- a/handler/src/main/java/com/networknt/handler/config/PathChain.java
+++ b/handler/src/main/java/com/networknt/handler/config/PathChain.java
@@ -62,8 +62,12 @@ public class PathChain {
                 problems.add("You must specify method along with path: " + path);
             }
         } else {
-            if(path != null) problems.add("Conflicting source: " + source + " and path: " + path);
-            if(path != null) problems.add("Conflicting source: " + source + " and method: " + method);
+            if(path != null) {
+                problems.add("Conflicting source: " + source + " and path: " + path);
+            }
+            if(method != null) {
+                problems.add("Conflicting source: " + source + " and method: " + method);
+            }
         }
         if(method != null && !NetUtils.METHODS.contains(method.toUpperCase())) {
             problems.add("Invalid HTTP method: " + method);

--- a/handler/src/main/java/com/networknt/handler/config/PathChain.java
+++ b/handler/src/main/java/com/networknt/handler/config/PathChain.java
@@ -53,7 +53,7 @@ public class PathChain {
      * Validate the settings and raise Exception on error.
      * The origin is used to help locate problems.
      */
-    public void validate(String origin) throws Exception {
+    public void validate(String origin) {
         List<String> problems = new ArrayList<>();
         if(source == null) {
             if(path == null) {
@@ -69,7 +69,7 @@ public class PathChain {
             problems.add("Invalid HTTP method: " + method);
         }
         if(!problems.isEmpty()) {
-            throw new Exception("Bad paths element in " + origin + " [ " + String.join(" | ", problems) + " ]");
+            throw new RuntimeException("Bad paths element in " + origin + " [ " + String.join(" | ", problems) + " ]");
         }
     }
 }

--- a/handler/src/test/java/com/networknt/handler/HandlerTest.java
+++ b/handler/src/test/java/com/networknt/handler/HandlerTest.java
@@ -1,10 +1,16 @@
 package com.networknt.handler;
 
+import com.networknt.handler.config.EndpointSource;
+import com.networknt.handler.config.PathChain;
 import com.networknt.utility.Tuple;
 import io.undertow.server.HttpHandler;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.PathTemplateMatcher;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -25,11 +31,73 @@ public class HandlerTest {
     }
 
     @Test
-    public void validConfig_init_handlersCreated() {
+    public void validConfig_init_handlersCreated() throws Exception {
     	Handler.init();
         Map<String, List<HttpHandler>> handlers = Handler.handlerListById;
         Assert.assertEquals(1, handlers.get("third").size());
         Assert.assertEquals(2, handlers.get("secondBeforeFirst").size());
+    }
+
+    private PathChain mkPathChain(String source, String path, String method, String... exec) throws Exception {
+        PathChain pc = new PathChain();
+        pc.setSource(source);
+        pc.setPath(path);
+        pc.setMethod(method);
+        pc.setExec(Arrays.asList(exec));
+        return pc;
+    }
+
+    static class MockEndpointSource implements EndpointSource {
+
+        @Override
+        public Iterable<EndpointSource.Endpoint> listEndpoints() {
+            return Arrays.asList(
+                new EndpointSource.Endpoint("/my-api/first", "get"),
+                new EndpointSource.Endpoint("/my-api/first", "put"),
+                new EndpointSource.Endpoint("/my-api/second", "get")
+            );
+        }
+    }
+
+    @Test
+    public void mixedPathsAndSource() throws Exception {
+        Handler.config.setPaths(Arrays.asList(
+            mkPathChain(null, "/my-api/first", "post", "third"),
+            mkPathChain(MockEndpointSource.class.getName(), null, null, "secondBeforeFirst", "third"),
+            mkPathChain(null, "/my-api/second", "put", "third")
+        ));
+        Handler.init();
+
+        Map<HttpString, PathTemplateMatcher<String>> methodToMatcher = Handler.methodToMatcherMap;
+
+        PathTemplateMatcher<String> getMatcher = methodToMatcher.get(Methods.GET);
+        PathTemplateMatcher.PathMatchResult<String> getFirst = getMatcher.match("/my-api/first");
+        Assert.assertNotNull(getFirst);
+        PathTemplateMatcher.PathMatchResult<String> getSecond = getMatcher.match("/my-api/second");
+        Assert.assertNotNull(getSecond);
+        PathTemplateMatcher.PathMatchResult<String> getThird = getMatcher.match("/my-api/third");
+        Assert.assertNull(getThird);
+    }
+
+    @Test
+    public void conflictingSourceAndPath_init_throws() throws Exception {
+        // Reconfigure path chain with an invalid path in the middle
+        Handler.config.setPaths(Arrays.asList(
+            mkPathChain(null, "/a/good/path", "POST", "third"),
+            mkPathChain("source", "/conflicting/path", "PUT", "third"),
+            mkPathChain("source", null, null, "some-chain", "third")
+        ));
+
+        // Use expectThrows when porting to java5.
+        // Not adding(exception=) to @Test since we care _where_ the exception is thrown
+        try {
+            Handler.init();
+            Assert.fail("Expected an exception to be thrown");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Conflicting source"));
+            Assert.assertTrue(e.getMessage().contains("and path"));
+            Assert.assertTrue(e.getMessage().contains("and method"));
+        }
     }
 
     @Test(expected = Exception.class)

--- a/handler/src/test/java/com/networknt/handler/HandlerTest.java
+++ b/handler/src/test/java/com/networknt/handler/HandlerTest.java
@@ -31,14 +31,14 @@ public class HandlerTest {
     }
 
     @Test
-    public void validConfig_init_handlersCreated() throws Exception {
+    public void validConfig_init_handlersCreated() {
     	Handler.init();
         Map<String, List<HttpHandler>> handlers = Handler.handlerListById;
         Assert.assertEquals(1, handlers.get("third").size());
         Assert.assertEquals(2, handlers.get("secondBeforeFirst").size());
     }
 
-    private PathChain mkPathChain(String source, String path, String method, String... exec) throws Exception {
+    private PathChain mkPathChain(String source, String path, String method, String... exec) {
         PathChain pc = new PathChain();
         pc.setSource(source);
         pc.setPath(path);
@@ -60,7 +60,7 @@ public class HandlerTest {
     }
 
     @Test
-    public void mixedPathsAndSource() throws Exception {
+    public void mixedPathsAndSource() {
         Handler.config.setPaths(Arrays.asList(
             mkPathChain(null, "/my-api/first", "post", "third"),
             mkPathChain(MockEndpointSource.class.getName(), null, null, "secondBeforeFirst", "third"),
@@ -80,7 +80,7 @@ public class HandlerTest {
     }
 
     @Test
-    public void conflictingSourceAndPath_init_throws() throws Exception {
+    public void conflictingSourceAndPath_init_throws() {
         // Reconfigure path chain with an invalid path in the middle
         Handler.config.setPaths(Arrays.asList(
             mkPathChain(null, "/a/good/path", "POST", "third"),

--- a/handler/src/test/java/com/networknt/handler/PathChainTest.java
+++ b/handler/src/test/java/com/networknt/handler/PathChainTest.java
@@ -1,0 +1,101 @@
+package com.networknt.handler;
+
+import com.networknt.handler.config.PathChain;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PathChainTest {
+
+    @Test
+    public void validate_Path() {
+        PathChain chain = new PathChain();
+        chain.setPath("/my/path");
+        chain.setMethod("GET");
+        chain.validate("unit test config");
+    }
+
+    @Test
+    public void validate_Source() {
+        PathChain chain = new PathChain();
+        chain.setSource("a.source.Class");
+        chain.validate("unit test config");
+    }
+
+    @Test
+    public void validate_NeitherPathNorSource() {
+        PathChain chain = new PathChain();
+        chain.setPath("/my/path");
+        chain.setMethod("MAGIC");
+        try {
+            chain.validate("unit test config");
+            Assert.fail("Expected exception");
+        } catch (Exception e) {
+            System.out.println(e.toString());
+            String ex_message = "Bad paths element in unit test config [ Invalid HTTP method: MAGIC ]";
+            Assert.assertEquals(ex_message, e.getMessage());
+        }
+    }
+
+    @Test
+    public void validate_BadMethod() {
+        PathChain chain = new PathChain();
+        chain.setMethod("GET");
+        try {
+            chain.validate("unit test config");
+            Assert.fail("Expected exception");
+        } catch (Exception e) {
+            System.out.println(e.toString());
+            String ex_message = "Bad paths element in unit test config [ You must specify either path or source ]";
+            Assert.assertEquals(ex_message, e.getMessage());
+        }
+    }
+
+    @Test
+    public void validate_SourceWithPathAndMethod() {
+        PathChain chain = new PathChain();
+        chain.setSource("some.source.Class");
+        chain.setPath("/some/path");
+        chain.setMethod("GET");
+        try {
+            chain.validate("some unit test");
+            Assert.fail("Expected exception");
+        } catch (Exception e) {
+            System.out.println(e.toString());
+            String ex_message = "Bad paths element in some unit test [ " +
+                "Conflicting source: some.source.Class and path: /some/path | " +
+                "Conflicting source: some.source.Class and method: GET ]";
+            Assert.assertEquals(ex_message, e.getMessage());
+        }
+    }
+
+    @Test
+    public void validate_SourceWithPath() {
+        PathChain chain = new PathChain();
+        chain.setSource("some.source.Class");
+        chain.setPath("/some/path");
+        try {
+            chain.validate("some unit test");
+            Assert.fail("Expected exception");
+        } catch (Exception e) {
+            System.out.println(e.toString());
+            String ex_message = "Bad paths element in some unit test [ Conflicting source: some.source.Class and path: /some/path ]";
+            Assert.assertEquals(ex_message, e.getMessage());
+        }
+    }
+
+    @Test
+    public void validate_SourceWithMethod() {
+        PathChain chain = new PathChain();
+        chain.setSource("some.source.Class");
+        chain.setMethod("GET");
+        try {
+            chain.validate("some unit test");
+            Assert.fail("Expected exception");
+        } catch (Exception e) {
+            System.out.println(e.toString());
+            String ex_message = "Bad paths element in some unit test [ Conflicting source: some.source.Class and method: GET ]";
+            Assert.assertEquals(ex_message, e.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
…method pairs into the list of paths at a particular location depending on the implementing class. Intended for injecting endpoints from OpenApi and Swagger spec files but may be useful for the standard graphql endpoints.