### PR TITLE
Refactored code from main() to init() so server can be embedded.

### DIFF
--- a/server/src/main/java/com/networknt/server/Server.java
+++ b/server/src/main/java/com/networknt/server/Server.java
@@ -111,6 +111,10 @@ public class Server {
     static GracefulShutdownHandler gracefulShutdownHandler;
 
     public static void main(final String[] args) {
+        init();
+    }
+
+    public static void init() {
         logger.info("server starts");
         // setup system property to redirect undertow logs to slf4j/logback.
         System.setProperty("org.jboss.logging.provider", "slf4j");


### PR DESCRIPTION
This address issue: https://github.com/networknt/light-4j/issues/312

I need to run the actual server from a system test program. Ideally the com.networknt.server.Server would allows doing this by moving the main methods content into an init() method that could be called from my test.This pull request addresses that need. Please consider merging in next release.