### PR TITLE
Fixing mutual tls on the server side

### DIFF
--- a/server/src/main/java/com/networknt/server/Server.java
+++ b/server/src/main/java/com/networknt/server/Server.java
@@ -361,7 +361,7 @@ public class Server {
 
     private static TrustManager[] buildTrustManagers(final KeyStore trustStore) {
         TrustManager[] trustManagers = null;
-        if (trustStore == null) {
+        if (trustStore != null) {
             try {
                 TrustManagerFactory trustManagerFactory = TrustManagerFactory
                         .getInstance(KeyManagerFactory.getDefaultAlgorithm());
@@ -372,6 +372,7 @@ public class Server {
                 throw new RuntimeException("Unable to initialise TrustManager[]", e);
             }
         } else {
+            logger.warn("Unable to find server truststore while Mutual TLS is enabled. Falling back to trust all certs.");
             trustManagers = TRUST_ALL_CERTS;
         }
         return trustManagers;

--- a/server/src/main/java/com/networknt/server/Server.java
+++ b/server/src/main/java/com/networknt/server/Server.java
@@ -47,6 +47,7 @@ import org.slf4j.MDC;
 import org.xnio.IoUtils;
 import org.xnio.OptionMap;
 import org.xnio.Options;
+import org.xnio.SslClientAuthMode;
 
 import javax.net.ssl.*;
 import java.io.BufferedInputStream;
@@ -215,6 +216,10 @@ public class Server {
             if (config.enableHttp2) {
                 builder.setServerOption(UndertowOptions.ENABLE_HTTP2, true);
             }
+
+            if (config.isEnableTwoWayTls()) {
+               builder.setSocketOption(Options.SSL_CLIENT_AUTH_MODE, SslClientAuthMode.REQUIRED);
+            }            
 
             server = builder.setBufferSize(1024 * 16).setIoThreads(Runtime.getRuntime().availableProcessors() * 2)
                     // above seems slightly faster in some configurations


### PR DESCRIPTION
@stevehu been looking into getting mutual tls on the server end working and there seem to be some issues.
I first noticed that this check seems to be inverted, but even after this fix it doesn't seem to be restricting access to only a client who can present the cert in the server truststore.

Have you ever had this working on your end?