### PR TITLE
fix typo, simplify RoundRobinLoadBalanceTest, add license info

### DIFF
--- a/balance/src/main/java/com/networknt/balance/ConsistentHashLoadBalance.java
+++ b/balance/src/main/java/com/networknt/balance/ConsistentHashLoadBalance.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.balance;
 
 import com.networknt.registry.URL;
@@ -7,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 /**
- * To obstain maximum scalability, microservices allow Y-Axis scale to break up big
+ * To obtain maximum scalability, microservices allow Y-Axis scale to break up big
  * monolithic application to small functional units. However, for some of the heavy
  * load services, we can use data sharding for Z-Axis scale. This load balance is
  * designed for that.

--- a/balance/src/main/java/com/networknt/balance/LoadBalance.java
+++ b/balance/src/main/java/com/networknt/balance/LoadBalance.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.balance;
 
 import com.networknt.registry.URL;

--- a/balance/src/main/java/com/networknt/balance/LocalFirstLoadBalance.java
+++ b/balance/src/main/java/com/networknt/balance/LocalFirstLoadBalance.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.balance;
 
 import com.networknt.registry.URL;
@@ -14,8 +30,8 @@ import java.util.List;
  * Local first load balance give local service high priority than remote services.
  * If there is no local service available, then it will adapt round robin strategy.
  *
- * With all the services in the list of urls, find local services with IP, Chances are
- * we have multiple local service, then round robin will be used in this case. If
+ * With all the services in the list of urls, find local services with IP. Chances are
+ * we have multiple local services, then round robin will be used in this case. If
  * there is no local service, find the first remote service according to round robin.
  *
  * Created by dan on 2016-12-29

--- a/balance/src/main/java/com/networknt/balance/RoundRobinLoadBalance.java
+++ b/balance/src/main/java/com/networknt/balance/RoundRobinLoadBalance.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.balance;
 
 import com.networknt.registry.URL;
@@ -8,14 +24,14 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Round Robin Loadbalance will pick up a url from a list of urls one by one
- * for each call. It will distributed the load equally to all urls in the list.
+ * Round Robin load balance will pick up a url from a list of urls one by one
+ * for each call. It will distribute the load equally to all urls in the list.
  *
  * This class has an instance variable called idx which is AtomicInteger and it
  * increases for every select call to make sure all urls in the list will have
  * an opportunity to be selected.
  *
- * The assumption for round robin is based on all service will have the same
+ * The assumption for round robin is based on all services will have the same
  * hardware/cloud resource configuration so that they can be treated as the
  * same priority without any weight.
  *
@@ -44,7 +60,6 @@ public class RoundRobinLoadBalance implements LoadBalance {
         URL url = null;
         if (urls.size() > 1) {
             url = doSelect(urls);
-
         } else if (urls.size() == 1) {
             url = urls.get(0);
         }

--- a/balance/src/test/java/com/networknt/balance/ConsitentHashLoadBalanceTest.java
+++ b/balance/src/test/java/com/networknt/balance/ConsitentHashLoadBalanceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.balance;
 
 import com.networknt.registry.URL;
@@ -14,7 +30,7 @@ import java.util.List;
  * Created by steve on 08/05/17.
  */
 public class ConsitentHashLoadBalanceTest {
-    LoadBalance loadBalance = new LocalFirstLoadBalance();
+    LoadBalance loadBalance = new ConsistentHashLoadBalance();
 
     @Test
     public void testSelect() throws Exception {

--- a/balance/src/test/java/com/networknt/balance/LocalFirstLoadBalanceTest.java
+++ b/balance/src/test/java/com/networknt/balance/LocalFirstLoadBalanceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.balance;
 
 import com.networknt.registry.URL;

--- a/balance/src/test/java/com/networknt/balance/RoundRobinLoadBalanceTest.java
+++ b/balance/src/test/java/com/networknt/balance/RoundRobinLoadBalanceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.balance;
 
 import com.networknt.registry.URL;
@@ -15,7 +31,7 @@ import java.util.List;
  * Created by steve on 2016-12-07.
  */
 public class RoundRobinLoadBalanceTest {
-    LoadBalance loadBalance = (LoadBalance) SingletonServiceFactory.getBean(LoadBalance.class);
+    LoadBalance loadBalance = new RoundRobinLoadBalance();
 
     @Test
     public void testSelect() throws Exception {

--- a/balance/src/test/resources/config/service.yml
+++ b/balance/src/test/resources/config/service.yml
@@ -1,6 +1,0 @@
-# Default load balance is round robin and it can be replace with another implementation.
----
-# singleton service factory configuration
-singletons:
-- com.networknt.balance.LoadBalance:
-  - com.networknt.balance.RoundRobinLoadBalance

--- a/balance/src/test/resources/logback-test.xml
+++ b/balance/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -25,8 +23,8 @@
     </turboFilter>
 
     <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
-    <!-- encoders are assigned the type
-         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5marker %-5level %logger{36} - %msg%n</pattern>
         </encoder>
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
-        <appender-ref ref="stdout" />
+        <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>


### PR DESCRIPTION
1. fix typo
2. don't use SingletonService to init RoundRobinLoadBalance, direct init it
3. remove un-used resource in test/
4. add license info