### PR TITLE
add missing license info, remove unused logback setting

### DIFF
--- a/client/src/integration/java/com/networknt/client/Http2ClientIT.java
+++ b/client/src/integration/java/com/networknt/client/Http2ClientIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client;
 
 import com.networknt.config.Config;

--- a/client/src/integration/resources/logback-test.xml
+++ b/client/src/integration/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="error">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/client/src/main/java/com/networknt/client/AsyncResponse.java
+++ b/client/src/main/java/com/networknt/client/AsyncResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client;
 
 import io.undertow.client.ClientResponse;

--- a/client/src/main/java/com/networknt/client/AsyncResult.java
+++ b/client/src/main/java/com/networknt/client/AsyncResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client;
 
 public interface AsyncResult<T> {

--- a/client/src/main/java/com/networknt/client/DefaultAsyncResult.java
+++ b/client/src/main/java/com/networknt/client/DefaultAsyncResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client;
 
 public class DefaultAsyncResult<T> implements AsyncResult<T> {

--- a/client/src/main/java/com/networknt/client/Http2Client.java
+++ b/client/src/main/java/com/networknt/client/Http2Client.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client;
 
 import java.io.IOException;

--- a/client/src/main/java/com/networknt/client/oauth/DerefRequest.java
+++ b/client/src/main/java/com/networknt/client/oauth/DerefRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.oauth;
 
 import com.networknt.client.Http2Client;

--- a/client/src/main/java/com/networknt/client/oauth/Jwt.java
+++ b/client/src/main/java/com/networknt/client/oauth/Jwt.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.oauth;
 
 import com.networknt.config.Config;

--- a/client/src/main/java/com/networknt/client/oauth/KeyRequest.java
+++ b/client/src/main/java/com/networknt/client/oauth/KeyRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.oauth;
 
 import com.networknt.client.Http2Client;

--- a/client/src/main/java/com/networknt/client/oauth/OauthHelper.java
+++ b/client/src/main/java/com/networknt/client/oauth/OauthHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.oauth;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/client/src/main/java/com/networknt/client/oauth/RefreshTokenRequest.java
+++ b/client/src/main/java/com/networknt/client/oauth/RefreshTokenRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.oauth;
 
 import com.networknt.client.Http2Client;

--- a/client/src/main/java/com/networknt/client/ssl/APINameChecker.java
+++ b/client/src/main/java/com/networknt/client/ssl/APINameChecker.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.ssl;
 
 import java.security.cert.CertificateException;

--- a/client/src/main/java/com/networknt/client/ssl/ClientX509ExtendedTrustManager.java
+++ b/client/src/main/java/com/networknt/client/ssl/ClientX509ExtendedTrustManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.ssl;
 
 import java.net.Socket;

--- a/client/src/main/java/com/networknt/client/ssl/EndpointIdentificationAlgorithm.java
+++ b/client/src/main/java/com/networknt/client/ssl/EndpointIdentificationAlgorithm.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.ssl;
 
 import java.net.Socket;

--- a/client/src/main/java/com/networknt/client/ssl/Light4jALPNClientSelector.java
+++ b/client/src/main/java/com/networknt/client/ssl/Light4jALPNClientSelector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.ssl;
 
 import java.io.IOException;

--- a/client/src/main/java/com/networknt/client/ssl/SSLUtils.java
+++ b/client/src/main/java/com/networknt/client/ssl/SSLUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.ssl;
 
 import java.security.cert.CertificateException;

--- a/client/src/main/java/com/networknt/client/ssl/TLSConfig.java
+++ b/client/src/main/java/com/networknt/client/ssl/TLSConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.ssl;
 
 import java.util.Arrays;

--- a/client/src/main/java/io/undertow/client/http/Light4jHttp2ClientProvider.java
+++ b/client/src/main/java/io/undertow/client/http/Light4jHttp2ClientProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.undertow.client.http;
 
 import java.net.InetSocketAddress;

--- a/client/src/main/java/io/undertow/client/http/Light4jHttpClientProvider.java
+++ b/client/src/main/java/io/undertow/client/http/Light4jHttpClientProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.undertow.client.http;
 
 import java.io.IOException;

--- a/client/src/test/java/com/networknt/client/Http2ClientTest.java
+++ b/client/src/test/java/com/networknt/client/Http2ClientTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client;
 
 import static org.junit.Assert.assertTrue;

--- a/client/src/test/java/com/networknt/client/oauth/OauthHelperTest.java
+++ b/client/src/test/java/com/networknt/client/oauth/OauthHelperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.oauth;
 
 import com.networknt.client.Http2Client;

--- a/client/src/test/java/com/networknt/client/oauth/TokenResponseTest.java
+++ b/client/src/test/java/com/networknt/client/oauth/TokenResponseTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.oauth;
 
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;

--- a/client/src/test/java/com/networknt/client/ssl/APINameCheckerTest.java
+++ b/client/src/test/java/com/networknt/client/ssl/APINameCheckerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.ssl;
 
 import static org.junit.Assert.assertFalse;

--- a/client/src/test/java/com/networknt/client/ssl/TLSConfigTest.java
+++ b/client/src/test/java/com/networknt/client/ssl/TLSConfigTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.client.ssl;
 
 import static org.junit.Assert.assertTrue;

--- a/client/src/test/resources/logback-test.xml
+++ b/client/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="error">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/cluster/src/main/java/com/networknt/cluster/Cluster.java
+++ b/cluster/src/main/java/com/networknt/cluster/Cluster.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.cluster;
 
 import java.net.URI;

--- a/cluster/src/main/java/com/networknt/cluster/LightCluster.java
+++ b/cluster/src/main/java/com/networknt/cluster/LightCluster.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.cluster;
 
 import com.networknt.balance.LoadBalance;

--- a/cluster/src/test/java/com/networknt/cluster/LightClusterTest.java
+++ b/cluster/src/test/java/com/networknt/cluster/LightClusterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.cluster;
 
 import com.networknt.service.SingletonServiceFactory;

--- a/cluster/src/test/resources/logback-test.xml
+++ b/cluster/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="debug">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/common/src/main/java/com/networknt/common/DecryptUtil.java
+++ b/common/src/main/java/com/networknt/common/DecryptUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.common;
 
 import com.networknt.service.SingletonServiceFactory;

--- a/common/src/main/java/com/networknt/common/SecretConstants.java
+++ b/common/src/main/java/com/networknt/common/SecretConstants.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.common;
 
 public class SecretConstants {

--- a/common/src/test/java/com/networknt/common/AESEncryptor.java
+++ b/common/src/test/java/com/networknt/common/AESEncryptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.common;
 
 import com.networknt.utility.Constants;

--- a/common/src/test/java/com/networknt/common/DecryptUtilTest.java
+++ b/common/src/test/java/com/networknt/common/DecryptUtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.common;
 
 import com.networknt.config.Config;

--- a/common/src/test/resources/logback-test.xml
+++ b/common/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/config/src/main/java/com/networknt/config/CentralizedManagement.java
+++ b/config/src/main/java/com/networknt/config/CentralizedManagement.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/config/src/main/java/com/networknt/config/ConfigException.java
+++ b/config/src/main/java/com/networknt/config/ConfigException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.config;
 
 /**

--- a/config/src/main/java/com/networknt/config/ConfigInjection.java
+++ b/config/src/main/java/com/networknt/config/ConfigInjection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.config;
 
 import java.util.ArrayList;

--- a/config/src/main/java/com/networknt/config/JsonMapper.java
+++ b/config/src/main/java/com/networknt/config/JsonMapper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/config/src/test/java/com/networknt/config/JsonMapperTest.java
+++ b/config/src/test/java/com/networknt/config/JsonMapperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.config;
 
 import org.junit.Test;

--- a/config/src/test/java/com/networknt/config/TestCentralizedManagement.java
+++ b/config/src/test/java/com/networknt/config/TestCentralizedManagement.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.config;
 
 import junit.framework.TestCase;

--- a/config/src/test/resources/logback-test.xml
+++ b/config/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/consul/src/integration/java/com/networknt/consul/ConsulTestIT.java
+++ b/consul/src/integration/java/com/networknt/consul/ConsulTestIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 import com.networknt.registry.Registry;
@@ -13,7 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class ConsulTest {
+public class ConsulTestIT {
     private ConsulRegistry registry;
     private URL serviceUrl;
     private long sleepTime;

--- a/consul/src/integration/resources/logback-test.xml
+++ b/consul/src/integration/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/consul/src/main/java/com/networknt/consul/ConsulConfig.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 public class ConsulConfig {

--- a/consul/src/main/java/com/networknt/consul/ConsulConstants.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulConstants.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 public class ConsulConstants {

--- a/consul/src/main/java/com/networknt/consul/ConsulHeartbeatManager.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulHeartbeatManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 import java.util.concurrent.ArrayBlockingQueue;

--- a/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 import com.networknt.client.Http2Client;

--- a/consul/src/main/java/com/networknt/consul/ConsulResponse.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 public class ConsulResponse<T> {

--- a/consul/src/main/java/com/networknt/consul/ConsulService.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 import com.networknt.config.Config;

--- a/consul/src/main/java/com/networknt/consul/ConsulUtils.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 import com.networknt.registry.URLImpl;

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClient.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul.client;
 
 import java.util.List;

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul.client;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/consul/src/test/java/com/networknt/consul/ConsulClientImplTest.java
+++ b/consul/src/test/java/com/networknt/consul/ConsulClientImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 import com.networknt.config.Config;

--- a/consul/src/test/java/com/networknt/consul/ConsulHeartbeatManagerTest.java
+++ b/consul/src/test/java/com/networknt/consul/ConsulHeartbeatManagerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 import static org.junit.Assert.assertTrue;

--- a/consul/src/test/java/com/networknt/consul/ConsulRegistryTest.java
+++ b/consul/src/test/java/com/networknt/consul/ConsulRegistryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 import com.networknt.consul.client.ConsulClient;

--- a/consul/src/test/java/com/networknt/consul/ConsulServiceTest.java
+++ b/consul/src/test/java/com/networknt/consul/ConsulServiceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 import com.networknt.config.Config;

--- a/consul/src/test/java/com/networknt/consul/ConsulUtilsTest.java
+++ b/consul/src/test/java/com/networknt/consul/ConsulUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 import com.networknt.registry.URL;

--- a/consul/src/test/java/com/networknt/consul/MockConsulClient.java
+++ b/consul/src/test/java/com/networknt/consul/MockConsulClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 import com.networknt.consul.client.ConsulClient;

--- a/consul/src/test/java/com/networknt/consul/MockUtils.java
+++ b/consul/src/test/java/com/networknt/consul/MockUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.consul;
 
 import com.networknt.registry.URLImpl;

--- a/consul/src/test/resources/logback-test.xml
+++ b/consul/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="debug">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/content/src/main/java/com/networknt/content/ContentConfig.java
+++ b/content/src/main/java/com/networknt/content/ContentConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.content;
 
 /**

--- a/content/src/main/java/com/networknt/content/ContentHandler.java
+++ b/content/src/main/java/com/networknt/content/ContentHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.content;
 
 import com.networknt.config.Config;

--- a/content/src/test/java/com/networknt/content/ContentHandlerTest.java
+++ b/content/src/test/java/com/networknt/content/ContentHandlerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.content;
 
 import com.networknt.client.Http2Client;

--- a/content/src/test/resources/logback-test.xml
+++ b/content/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/correlation/src/test/resources/logback-test.xml
+++ b/correlation/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/cors/src/main/java/com/networknt/cors/CorsConfig.java
+++ b/cors/src/main/java/com/networknt/cors/CorsConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.cors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/cors/src/test/java/com/networknt/cors/CorsHttpHandlerTest.java
+++ b/cors/src/test/java/com/networknt/cors/CorsHttpHandlerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.cors;
 
 import com.networknt.client.Http2Client;

--- a/cors/src/test/resources/logback-test.xml
+++ b/cors/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/data-source/src/main/java/com/networknt/db/GenericDataSource.java
+++ b/data-source/src/main/java/com/networknt/db/GenericDataSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.db;
 
 import com.networknt.common.DecryptUtil;

--- a/data-source/src/main/java/com/networknt/db/H2DataSource.java
+++ b/data-source/src/main/java/com/networknt/db/H2DataSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.db;
 
 /**

--- a/data-source/src/main/java/com/networknt/db/MariaDataSource.java
+++ b/data-source/src/main/java/com/networknt/db/MariaDataSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.db;
 
 /**

--- a/data-source/src/main/java/com/networknt/db/MysqlDataSource.java
+++ b/data-source/src/main/java/com/networknt/db/MysqlDataSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.db;
 
 /**

--- a/data-source/src/main/java/com/networknt/db/OracleDataSource.java
+++ b/data-source/src/main/java/com/networknt/db/OracleDataSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.db;
 
 /**

--- a/data-source/src/main/java/com/networknt/db/PostgresDataSource.java
+++ b/data-source/src/main/java/com/networknt/db/PostgresDataSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.db;
 
 /**

--- a/data-source/src/main/java/com/networknt/db/SqlServerDataSource.java
+++ b/data-source/src/main/java/com/networknt/db/SqlServerDataSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.db;
 
 /**

--- a/data-source/src/test/java/com/networknt/db/GenericDataSourceTest.java
+++ b/data-source/src/test/java/com/networknt/db/GenericDataSourceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.db;
 
 import com.networknt.service.SingletonServiceFactory;

--- a/data-source/src/test/resources/logback-test.xml
+++ b/data-source/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/decryptor/src/main/java/com/networknt/decrypt/AESDecryptor.java
+++ b/decryptor/src/main/java/com/networknt/decrypt/AESDecryptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.decrypt;
 
 import com.networknt.utility.Constants;

--- a/deref-token/src/main/java/com/networknt/deref/DerefConfig.java
+++ b/deref-token/src/main/java/com/networknt/deref/DerefConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.deref;
 
 /**

--- a/deref-token/src/main/java/com/networknt/deref/DerefMiddlewareHandler.java
+++ b/deref-token/src/main/java/com/networknt/deref/DerefMiddlewareHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.deref;
 
 import com.networknt.client.oauth.DerefRequest;

--- a/dump/src/main/java/com/networknt/dump/AbstractDumper.java
+++ b/dump/src/main/java/com/networknt/dump/AbstractDumper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import io.undertow.server.HttpServerExchange;

--- a/dump/src/main/java/com/networknt/dump/BodyDumper.java
+++ b/dump/src/main/java/com/networknt/dump/BodyDumper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import com.networknt.body.BodyHandler;

--- a/dump/src/main/java/com/networknt/dump/CookiesDumper.java
+++ b/dump/src/main/java/com/networknt/dump/CookiesDumper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import com.networknt.mask.Mask;

--- a/dump/src/main/java/com/networknt/dump/DumpConfig.java
+++ b/dump/src/main/java/com/networknt/dump/DumpConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import java.util.ArrayList;

--- a/dump/src/main/java/com/networknt/dump/DumpConstants.java
+++ b/dump/src/main/java/com/networknt/dump/DumpConstants.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 class DumpConstants {

--- a/dump/src/main/java/com/networknt/dump/DumpHelper.java
+++ b/dump/src/main/java/com/networknt/dump/DumpHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/dump/src/main/java/com/networknt/dump/DumperFactory.java
+++ b/dump/src/main/java/com/networknt/dump/DumperFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import io.undertow.server.HttpServerExchange;

--- a/dump/src/main/java/com/networknt/dump/HeadersDumper.java
+++ b/dump/src/main/java/com/networknt/dump/HeadersDumper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import com.networknt.mask.Mask;

--- a/dump/src/main/java/com/networknt/dump/IRequestDumpable.java
+++ b/dump/src/main/java/com/networknt/dump/IRequestDumpable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import java.util.Map;

--- a/dump/src/main/java/com/networknt/dump/IResponseDumpable.java
+++ b/dump/src/main/java/com/networknt/dump/IResponseDumpable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import java.util.Map;

--- a/dump/src/main/java/com/networknt/dump/QueryParametersDumper.java
+++ b/dump/src/main/java/com/networknt/dump/QueryParametersDumper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import com.networknt.mask.Mask;

--- a/dump/src/main/java/com/networknt/dump/RootDumper.java
+++ b/dump/src/main/java/com/networknt/dump/RootDumper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import io.undertow.server.HttpServerExchange;

--- a/dump/src/main/java/com/networknt/dump/StatusCodeDumper.java
+++ b/dump/src/main/java/com/networknt/dump/StatusCodeDumper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import com.networknt.utility.StringUtils;

--- a/dump/src/main/java/com/networknt/dump/StoreResponseStreamSinkConduit.java
+++ b/dump/src/main/java/com/networknt/dump/StoreResponseStreamSinkConduit.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import io.undertow.UndertowMessages;

--- a/dump/src/main/java/com/networknt/dump/UrlDumper.java
+++ b/dump/src/main/java/com/networknt/dump/UrlDumper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.dump;
 
 import com.networknt.mask.Mask;

--- a/dump/src/test/resources/logback-test.xml
+++ b/dump/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/email-sender/src/main/java/com/networknt/email/EmailConfig.java
+++ b/email-sender/src/main/java/com/networknt/email/EmailConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.email;
 
 /**

--- a/email-sender/src/main/java/com/networknt/email/EmailSender.java
+++ b/email-sender/src/main/java/com/networknt/email/EmailSender.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.email;
 
 import com.networknt.common.DecryptUtil;

--- a/email-sender/src/test/java/com/networknt/email/EmailSenderTest.java
+++ b/email-sender/src/test/java/com/networknt/email/EmailSenderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.email;
 
 import org.junit.Test;

--- a/email-sender/src/test/resources/logback-test.xml
+++ b/email-sender/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/encode-decode/src/main/java/com/networknt/decode/RequestDecodeConfig.java
+++ b/encode-decode/src/main/java/com/networknt/decode/RequestDecodeConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.decode;
 
 import java.util.List;

--- a/encode-decode/src/main/java/com/networknt/decode/RequestDecodeHandler.java
+++ b/encode-decode/src/main/java/com/networknt/decode/RequestDecodeHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.decode;
 
 import com.networknt.config.Config;

--- a/encode-decode/src/main/java/com/networknt/encode/ResponseEncodeConfig.java
+++ b/encode-decode/src/main/java/com/networknt/encode/ResponseEncodeConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.encode;
 
 import java.util.List;

--- a/encode-decode/src/main/java/com/networknt/encode/ResponseEncodeHandler.java
+++ b/encode-decode/src/main/java/com/networknt/encode/ResponseEncodeHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.encode;
 
 import com.networknt.config.Config;

--- a/encode-decode/src/test/java/com/networknt/EncodeDecodeHandlerTest.java
+++ b/encode-decode/src/test/java/com/networknt/EncodeDecodeHandlerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt;
 
 import com.networknt.decode.RequestDecodeHandler;

--- a/encode-decode/src/test/java/com/networknt/HttpClientUtils.java
+++ b/encode-decode/src/test/java/com/networknt/HttpClientUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt;
 
 import org.apache.http.HttpEntity;

--- a/encode-decode/src/test/java/com/networknt/decode/RequestDecodeConfigTest.java
+++ b/encode-decode/src/test/java/com/networknt/decode/RequestDecodeConfigTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.decode;
 
 import com.networknt.config.Config;

--- a/encode-decode/src/test/java/com/networknt/encode/ResponseEncodeConfigTest.java
+++ b/encode-decode/src/test/java/com/networknt/encode/ResponseEncodeConfigTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.encode;
 
 import com.networknt.config.Config;

--- a/encode-decode/src/test/resources/logback-test.xml
+++ b/encode-decode/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="error">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="debug">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/exception/src/test/resources/logback-test.xml
+++ b/exception/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/handler/src/main/java/com/networknt/handler/Handler.java
+++ b/handler/src/main/java/com/networknt/handler/Handler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler;
 
 import com.networknt.utility.Tuple;

--- a/handler/src/main/java/com/networknt/handler/LightHttpHandler.java
+++ b/handler/src/main/java/com/networknt/handler/LightHttpHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler;
 
 import com.networknt.status.Status;

--- a/handler/src/main/java/com/networknt/handler/OrchestrationHandler.java
+++ b/handler/src/main/java/com/networknt/handler/OrchestrationHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler;
 
 import io.undertow.server.HttpServerExchange;

--- a/handler/src/main/java/com/networknt/handler/config/EndpointSource.java
+++ b/handler/src/main/java/com/networknt/handler/config/EndpointSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler.config;
 
 import java.util.Objects;

--- a/handler/src/main/java/com/networknt/handler/config/HandlerConfig.java
+++ b/handler/src/main/java/com/networknt/handler/config/HandlerConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler.config;
 
 import java.util.List;

--- a/handler/src/main/java/com/networknt/handler/config/HandlerPath.java
+++ b/handler/src/main/java/com/networknt/handler/config/HandlerPath.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler.config;
 
 import java.util.List;

--- a/handler/src/main/java/com/networknt/handler/config/NamedMiddlewareChain.java
+++ b/handler/src/main/java/com/networknt/handler/config/NamedMiddlewareChain.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler.config;
 
 import java.util.List;

--- a/handler/src/main/java/com/networknt/handler/config/PathChain.java
+++ b/handler/src/main/java/com/networknt/handler/config/PathChain.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler.config;
 
 import com.networknt.utility.NetUtils;

--- a/handler/src/main/java/com/networknt/handler/config/PathHandler.java
+++ b/handler/src/main/java/com/networknt/handler/config/PathHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler.config;
 
 import java.util.List;

--- a/handler/src/test/java/com/networknt/handler/HandlerTest.java
+++ b/handler/src/test/java/com/networknt/handler/HandlerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler;
 
 import com.networknt.handler.config.EndpointSource;

--- a/handler/src/test/java/com/networknt/handler/PathChainTest.java
+++ b/handler/src/test/java/com/networknt/handler/PathChainTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler;
 
 import com.networknt.handler.config.PathChain;

--- a/handler/src/test/java/com/networknt/handler/sample/SampleHttpHandler1.java
+++ b/handler/src/test/java/com/networknt/handler/sample/SampleHttpHandler1.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler.sample;
 
 import com.networknt.handler.LightHttpHandler;

--- a/handler/src/test/java/com/networknt/handler/sample/SampleHttpHandler2.java
+++ b/handler/src/test/java/com/networknt/handler/sample/SampleHttpHandler2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler.sample;
 
 import com.networknt.handler.LightHttpHandler;

--- a/handler/src/test/java/com/networknt/handler/sample/SampleHttpHandler3.java
+++ b/handler/src/test/java/com/networknt/handler/sample/SampleHttpHandler3.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.handler.sample;
 
 import com.networknt.handler.LightHttpHandler;

--- a/handler/src/test/resources/logback-test.xml
+++ b/handler/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/header/src/test/resources/logback-test.xml
+++ b/header/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/health/src/test/resources/logback-test.xml
+++ b/health/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/http-string/src/main/java/com/networknt/httpstring/ContentType.java
+++ b/http-string/src/main/java/com/networknt/httpstring/ContentType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.httpstring;
 
 /**

--- a/info/src/test/resources/logback-test.xml
+++ b/info/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/ip-whitelist/src/main/java/com/networknt/whitelist/IpAcl.java
+++ b/ip-whitelist/src/main/java/com/networknt/whitelist/IpAcl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.whitelist;
 
 import java.util.ArrayList;

--- a/ip-whitelist/src/main/java/com/networknt/whitelist/WhitelistConfig.java
+++ b/ip-whitelist/src/main/java/com/networknt/whitelist/WhitelistConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.whitelist;
 
 import org.xnio.Bits;

--- a/ip-whitelist/src/main/java/com/networknt/whitelist/WhitelistHandler.java
+++ b/ip-whitelist/src/main/java/com/networknt/whitelist/WhitelistHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.whitelist;
 
 import com.networknt.config.Config;

--- a/ip-whitelist/src/test/java/com/networknt/whitelist/WhitelistConfigTest.java
+++ b/ip-whitelist/src/test/java/com/networknt/whitelist/WhitelistConfigTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.whitelist;
 
 import com.networknt.config.Config;

--- a/ip-whitelist/src/test/java/com/networknt/whitelist/WhitelistHandlerTest.java
+++ b/ip-whitelist/src/test/java/com/networknt/whitelist/WhitelistHandlerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.whitelist;
 
 import com.networknt.client.Http2Client;

--- a/ip-whitelist/src/test/resources/logback-test.xml
+++ b/ip-whitelist/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/mask/src/test/resources/logback-test.xml
+++ b/mask/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/metrics/src/main/java/io/dropwizard/metrics/CachedGauge.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/CachedGauge.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.util.concurrent.TimeUnit;

--- a/metrics/src/main/java/io/dropwizard/metrics/Clock.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Clock.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.lang.management.ManagementFactory;

--- a/metrics/src/main/java/io/dropwizard/metrics/ConsoleReporter.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/ConsoleReporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.io.PrintStream;

--- a/metrics/src/main/java/io/dropwizard/metrics/Counter.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Counter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 /**

--- a/metrics/src/main/java/io/dropwizard/metrics/Counting.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Counting.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 /**

--- a/metrics/src/main/java/io/dropwizard/metrics/DefaultObjectNameFactory.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/DefaultObjectNameFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import javax.management.MalformedObjectNameException;

--- a/metrics/src/main/java/io/dropwizard/metrics/DerivativeGauge.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/DerivativeGauge.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 /**

--- a/metrics/src/main/java/io/dropwizard/metrics/EWMA.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/EWMA.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.util.concurrent.TimeUnit;

--- a/metrics/src/main/java/io/dropwizard/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/ExponentiallyDecayingReservoir.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.util.ArrayList;

--- a/metrics/src/main/java/io/dropwizard/metrics/Gauge.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Gauge.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 /**

--- a/metrics/src/main/java/io/dropwizard/metrics/HdrHistogramReservoir.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/HdrHistogramReservoir.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.HdrHistogram.Histogram;

--- a/metrics/src/main/java/io/dropwizard/metrics/HdrHistogramResetOnSnapshotReservoir.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/HdrHistogramResetOnSnapshotReservoir.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.HdrHistogram.Histogram;

--- a/metrics/src/main/java/io/dropwizard/metrics/Histogram.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Histogram.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.io.ByteArrayOutputStream;

--- a/metrics/src/main/java/io/dropwizard/metrics/HistogramSnapshot.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/HistogramSnapshot.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.HdrHistogram.Histogram;

--- a/metrics/src/main/java/io/dropwizard/metrics/InstrumentedExecutorService.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/InstrumentedExecutorService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import javax.annotation.Nonnull;

--- a/metrics/src/main/java/io/dropwizard/metrics/InstrumentedExecutors.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/InstrumentedExecutors.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.util.concurrent.ExecutorService;

--- a/metrics/src/main/java/io/dropwizard/metrics/InstrumentedScheduledExecutorService.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/InstrumentedScheduledExecutorService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import javax.annotation.Nonnull;

--- a/metrics/src/main/java/io/dropwizard/metrics/InstrumentedThreadFactory.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/InstrumentedThreadFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import javax.annotation.Nonnull;

--- a/metrics/src/main/java/io/dropwizard/metrics/JmxAttributeGauge.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/JmxAttributeGauge.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.io.IOException;

--- a/metrics/src/main/java/io/dropwizard/metrics/JmxReporter.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/JmxReporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.slf4j.Logger;

--- a/metrics/src/main/java/io/dropwizard/metrics/JvmAttributeGaugeSet.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/JvmAttributeGaugeSet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.lang.management.ManagementFactory;

--- a/metrics/src/main/java/io/dropwizard/metrics/Meter.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Meter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.util.concurrent.TimeUnit;

--- a/metrics/src/main/java/io/dropwizard/metrics/Metered.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Metered.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 /**

--- a/metrics/src/main/java/io/dropwizard/metrics/Metric.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Metric.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 /**

--- a/metrics/src/main/java/io/dropwizard/metrics/MetricFilter.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/MetricFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 /**

--- a/metrics/src/main/java/io/dropwizard/metrics/MetricName.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/MetricName.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import javax.annotation.Nonnull;

--- a/metrics/src/main/java/io/dropwizard/metrics/MetricRegistry.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/MetricRegistry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import io.dropwizard.metrics.Counter;

--- a/metrics/src/main/java/io/dropwizard/metrics/MetricRegistryListener.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/MetricRegistryListener.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.util.EventListener;

--- a/metrics/src/main/java/io/dropwizard/metrics/MetricSet.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/MetricSet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.util.Map;

--- a/metrics/src/main/java/io/dropwizard/metrics/ObjectNameFactory.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/ObjectNameFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import javax.management.ObjectName;

--- a/metrics/src/main/java/io/dropwizard/metrics/RatioGauge.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/RatioGauge.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import static java.lang.Double.isInfinite;

--- a/metrics/src/main/java/io/dropwizard/metrics/Reporter.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Reporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 /*

--- a/metrics/src/main/java/io/dropwizard/metrics/Reservoir.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Reservoir.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 /**

--- a/metrics/src/main/java/io/dropwizard/metrics/Sampling.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Sampling.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 /**

--- a/metrics/src/main/java/io/dropwizard/metrics/ScheduledReporter.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/ScheduledReporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.io.Closeable;

--- a/metrics/src/main/java/io/dropwizard/metrics/SharedMetricRegistries.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/SharedMetricRegistries.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.util.Set;

--- a/metrics/src/main/java/io/dropwizard/metrics/Slf4jReporter.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Slf4jReporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.slf4j.Logger;

--- a/metrics/src/main/java/io/dropwizard/metrics/SlidingTimeWindowReservoir.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/SlidingTimeWindowReservoir.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.util.concurrent.ConcurrentSkipListMap;

--- a/metrics/src/main/java/io/dropwizard/metrics/SlidingWindowReservoir.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/SlidingWindowReservoir.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import static java.lang.Math.min;

--- a/metrics/src/main/java/io/dropwizard/metrics/Snapshot.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Snapshot.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.io.OutputStream;

--- a/metrics/src/main/java/io/dropwizard/metrics/Timer.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/Timer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.util.concurrent.Callable;

--- a/metrics/src/main/java/io/dropwizard/metrics/UniformReservoir.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/UniformReservoir.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.util.concurrent.ThreadLocalRandom;

--- a/metrics/src/main/java/io/dropwizard/metrics/UniformSnapshot.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/UniformSnapshot.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.io.OutputStream;

--- a/metrics/src/main/java/io/dropwizard/metrics/WeightedSnapshot.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/WeightedSnapshot.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import java.io.OutputStream;

--- a/metrics/src/main/java/io/dropwizard/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/influxdb/InfluxDbHttpSender.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics.influxdb;
 
 import com.networknt.client.Http2Client;

--- a/metrics/src/main/java/io/dropwizard/metrics/influxdb/InfluxDbReporter.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/influxdb/InfluxDbReporter.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics.influxdb;
 
 import java.util.*;

--- a/metrics/src/main/java/io/dropwizard/metrics/influxdb/InfluxDbSender.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/influxdb/InfluxDbSender.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics.influxdb;
 
 import java.util.Map;

--- a/metrics/src/main/java/io/dropwizard/metrics/influxdb/data/InfluxDbPoint.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/influxdb/data/InfluxDbPoint.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics.influxdb.data;
 
 import java.util.Collections;

--- a/metrics/src/main/java/io/dropwizard/metrics/influxdb/data/InfluxDbWriteObject.java
+++ b/metrics/src/main/java/io/dropwizard/metrics/influxdb/data/InfluxDbWriteObject.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics.influxdb.data;
 
 import java.util.*;

--- a/metrics/src/test/java/io/dropwizard/metrics/CachedGaugeTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/CachedGaugeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/ClockTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/ClockTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/ConsoleReporterTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/ConsoleReporterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Before;

--- a/metrics/src/test/java/io/dropwizard/metrics/CounterTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/CounterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/DefaultObjectNameFactoryTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/DefaultObjectNameFactoryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/metrics/src/test/java/io/dropwizard/metrics/DerivativeGaugeTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/DerivativeGaugeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/EWMATest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/EWMATest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/ExponentiallyDecayingReservoirTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/ExponentiallyDecayingReservoirTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/HistogramTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/HistogramTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/InstrumentedExecutorServiceTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/InstrumentedExecutorServiceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.After;

--- a/metrics/src/test/java/io/dropwizard/metrics/InstrumentedExecutorsTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/InstrumentedExecutorsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Before;

--- a/metrics/src/test/java/io/dropwizard/metrics/InstrumentedScheduledExecutorServiceTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/InstrumentedScheduledExecutorServiceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.After;

--- a/metrics/src/test/java/io/dropwizard/metrics/InstrumentedThreadFactoryTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/InstrumentedThreadFactoryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/metrics/src/test/java/io/dropwizard/metrics/JmxAttributeGaugeTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/JmxAttributeGaugeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/metrics/src/test/java/io/dropwizard/metrics/JmxReporterTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/JmxReporterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.After;

--- a/metrics/src/test/java/io/dropwizard/metrics/JvmAttributeGaugeSetTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/JvmAttributeGaugeSetTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Before;

--- a/metrics/src/test/java/io/dropwizard/metrics/ManualClock.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/ManualClock.java
@@ -1,6 +1,20 @@
-package io.dropwizard.metrics;
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import io.dropwizard.metrics.Clock;
+package io.dropwizard.metrics;
 
 import java.util.concurrent.TimeUnit;
 

--- a/metrics/src/test/java/io/dropwizard/metrics/MeterApproximationTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/MeterApproximationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/MeterTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/MeterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Before;

--- a/metrics/src/test/java/io/dropwizard/metrics/MetricFilterTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/MetricFilterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/MetricNameTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/MetricNameTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/metrics/src/test/java/io/dropwizard/metrics/MetricRegistryListenerTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/MetricRegistryListenerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/MetricRegistryTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/MetricRegistryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import static io.dropwizard.metrics.MetricRegistry.name;

--- a/metrics/src/test/java/io/dropwizard/metrics/RatioGaugeTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/RatioGaugeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/ScheduledReporterTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/ScheduledReporterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.After;

--- a/metrics/src/test/java/io/dropwizard/metrics/SharedMetricRegistriesTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/SharedMetricRegistriesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Before;

--- a/metrics/src/test/java/io/dropwizard/metrics/Slf4jReporterTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/Slf4jReporterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/SlidingTimeWindowReservoirTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/SlidingTimeWindowReservoirTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/SlidingWindowReservoirTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/SlidingWindowReservoirTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/TimerTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/TimerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/UniformReservoirTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/UniformReservoirTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/UniformSnapshotTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/UniformSnapshotTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/WeightedSnapshotTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/WeightedSnapshotTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics;
 
 import org.junit.Test;

--- a/metrics/src/test/java/io/dropwizard/metrics/influxdb/InfluxDbReporterTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/influxdb/InfluxDbReporterTest.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics.influxdb;
 
 import static org.mockito.Mockito.*;

--- a/metrics/src/test/java/io/dropwizard/metrics/influxdb/data/InfluxDbPointTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/influxdb/data/InfluxDbPointTest.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.dropwizard.metrics.influxdb.data;
 
 import org.junit.Assert;

--- a/metrics/src/test/java/sandbox/SendToLocalInfluxDB.java
+++ b/metrics/src/test/java/sandbox/SendToLocalInfluxDB.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sandbox;
 
 import java.util.HashMap;

--- a/metrics/src/test/resources/logback-test.xml
+++ b/metrics/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="error">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/monad-result/src/main/java/com/networknt/monad/Failure.java
+++ b/monad-result/src/main/java/com/networknt/monad/Failure.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.monad;
 
 import com.networknt.status.Status;

--- a/monad-result/src/main/java/com/networknt/monad/Result.java
+++ b/monad-result/src/main/java/com/networknt/monad/Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.monad;
 
 import com.networknt.status.Status;

--- a/monad-result/src/main/java/com/networknt/monad/Success.java
+++ b/monad-result/src/main/java/com/networknt/monad/Success.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.monad;
 
 import com.networknt.status.Status;

--- a/monad-result/src/test/java/com/networknt/monad/ResultTest.java
+++ b/monad-result/src/test/java/com/networknt/monad/ResultTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.monad;
 
 import com.networknt.status.Status;

--- a/monad-result/src/test/resources/logback-test.xml
+++ b/monad-result/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/rate-limit/src/test/resources/logback-test.xml
+++ b/rate-limit/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="error">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="debug">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/registry/src/main/java/com/networknt/registry/URLImpl.java
+++ b/registry/src/main/java/com/networknt/registry/URLImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.registry;
 
 import com.networknt.utility.Constants;

--- a/registry/src/test/resources/logback-test.xml
+++ b/registry/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/resource/src/main/java/com/networknt/resource/PathResourceConfig.java
+++ b/resource/src/main/java/com/networknt/resource/PathResourceConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.resource;
 
 import java.util.List;

--- a/resource/src/main/java/com/networknt/resource/PathResourceHandler.java
+++ b/resource/src/main/java/com/networknt/resource/PathResourceHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.resource;
 
 import com.networknt.config.Config;

--- a/resource/src/main/java/com/networknt/resource/PathResourceProvider.java
+++ b/resource/src/main/java/com/networknt/resource/PathResourceProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.resource;
 
 import io.undertow.server.handlers.resource.ResourceManager;

--- a/resource/src/main/java/com/networknt/resource/PredicatedHandlersProvider.java
+++ b/resource/src/main/java/com/networknt/resource/PredicatedHandlersProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.resource;
 
 import io.undertow.server.handlers.builder.PredicatedHandler;

--- a/resource/src/main/java/com/networknt/resource/ResourceHelpers.java
+++ b/resource/src/main/java/com/networknt/resource/ResourceHelpers.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.resource;
 
 import io.undertow.server.handlers.PathHandler;

--- a/resource/src/main/java/com/networknt/resource/VirtualHost.java
+++ b/resource/src/main/java/com/networknt/resource/VirtualHost.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.resource;
 
 public class VirtualHost {

--- a/resource/src/main/java/com/networknt/resource/VirtualHostConfig.java
+++ b/resource/src/main/java/com/networknt/resource/VirtualHostConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.resource;
 
 import java.util.List;

--- a/resource/src/main/java/com/networknt/resource/VirtualHostHandler.java
+++ b/resource/src/main/java/com/networknt/resource/VirtualHostHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.resource;
 
 import com.networknt.config.Config;

--- a/resource/src/test/java/com/networknt/resource/PathResourceConfigHandlerTest.java
+++ b/resource/src/test/java/com/networknt/resource/PathResourceConfigHandlerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.resource;
 
 import com.networknt.client.Http2Client;

--- a/resource/src/test/java/com/networknt/resource/PathResourceConfigTest.java
+++ b/resource/src/test/java/com/networknt/resource/PathResourceConfigTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.resource;
 
 import com.networknt.config.Config;

--- a/resource/src/test/java/com/networknt/resource/VirtualHostConfigTest.java
+++ b/resource/src/test/java/com/networknt/resource/VirtualHostConfigTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.resource;
 
 import com.networknt.config.Config;

--- a/sanitizer/src/main/java/com/networknt/sanitizer/SanitizerConfig.java
+++ b/sanitizer/src/main/java/com/networknt/sanitizer/SanitizerConfig.java
@@ -1,6 +1,20 @@
-package com.networknt.sanitizer;
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+package com.networknt.sanitizer;
 
 /**
  * Sanitizer configuration class

--- a/sanitizer/src/main/java/com/networknt/sanitizer/SanitizerHandler.java
+++ b/sanitizer/src/main/java/com/networknt/sanitizer/SanitizerHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.sanitizer;
 
 import com.networknt.body.BodyHandler;

--- a/sanitizer/src/test/java/com/networknt/sanitizer/SanitizerHandlerTest.java
+++ b/sanitizer/src/test/java/com/networknt/sanitizer/SanitizerHandlerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.sanitizer;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/sanitizer/src/test/resources/logback-test.xml
+++ b/sanitizer/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/security/src/main/java/com/networknt/security/inbound/MessageVerifier.java
+++ b/security/src/main/java/com/networknt/security/inbound/MessageVerifier.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.security.inbound;
 
 import com.networknt.security.outbound.SignedMessage;

--- a/security/src/main/java/com/networknt/security/inbound/RequestFilterHandler.java
+++ b/security/src/main/java/com/networknt/security/inbound/RequestFilterHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.security.inbound;
 
 import com.networknt.handler.LightHttpHandler;

--- a/security/src/main/java/com/networknt/security/inbound/RoleBasedAuthHandler.java
+++ b/security/src/main/java/com/networknt/security/inbound/RoleBasedAuthHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.security.inbound;
 
 import com.networknt.handler.LightHttpHandler;

--- a/security/src/main/java/com/networknt/security/inbound/VerificationException.java
+++ b/security/src/main/java/com/networknt/security/inbound/VerificationException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.security.inbound;
 
 /**

--- a/security/src/main/java/com/networknt/security/inbound/VerifiedMessage.java
+++ b/security/src/main/java/com/networknt/security/inbound/VerifiedMessage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.security.inbound;
 
 /**

--- a/security/src/main/java/com/networknt/security/outbound/Message.java
+++ b/security/src/main/java/com/networknt/security/outbound/Message.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.security.outbound;
 
 /**

--- a/security/src/main/java/com/networknt/security/outbound/MessageSigner.java
+++ b/security/src/main/java/com/networknt/security/outbound/MessageSigner.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.security.outbound;
 
 /**

--- a/security/src/main/java/com/networknt/security/outbound/ResponseFilterHandler.java
+++ b/security/src/main/java/com/networknt/security/outbound/ResponseFilterHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.security.outbound;
 
 import com.networknt.handler.LightHttpHandler;

--- a/security/src/main/java/com/networknt/security/outbound/SignedMessage.java
+++ b/security/src/main/java/com/networknt/security/outbound/SignedMessage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.security.outbound;
 
 /**

--- a/security/src/test/java/com/networknt/security/ClaimsUtil.java
+++ b/security/src/test/java/com/networknt/security/ClaimsUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.security;
 
 import org.jose4j.jwt.JwtClaims;

--- a/security/src/test/java/com/networknt/security/JwtIssuerTest.java
+++ b/security/src/test/java/com/networknt/security/JwtIssuerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.security;
 
 import org.jose4j.jwt.JwtClaims;

--- a/security/src/test/resources/logback-test.xml
+++ b/security/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/server/src/main/java/com/networknt/server/DummyTrustManager.java
+++ b/server/src/main/java/com/networknt/server/DummyTrustManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 import javax.net.ssl.X509TrustManager;

--- a/server/src/main/java/com/networknt/server/JsonPathStartupHookProvider.java
+++ b/server/src/main/java/com/networknt/server/JsonPathStartupHookProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 import com.jayway.jsonpath.Configuration;

--- a/server/src/main/java/com/networknt/server/ShutdownHookProvider.java
+++ b/server/src/main/java/com/networknt/server/ShutdownHookProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 /**

--- a/server/src/main/java/com/networknt/server/StartupHookProvider.java
+++ b/server/src/main/java/com/networknt/server/StartupHookProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 /**

--- a/server/src/test/java/com/networknt/server/RegistryTest.java
+++ b/server/src/test/java/com/networknt/server/RegistryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 import com.networknt.config.Config;

--- a/server/src/test/java/com/networknt/server/ServerConfigTest.java
+++ b/server/src/test/java/com/networknt/server/ServerConfigTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 import com.networknt.config.Config;

--- a/server/src/test/java/com/networknt/server/ServerTest.java
+++ b/server/src/test/java/com/networknt/server/ServerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 import com.networknt.client.Http2Client;

--- a/server/src/test/java/com/networknt/server/Test1MiddlewareHandler.java
+++ b/server/src/test/java/com/networknt/server/Test1MiddlewareHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 import com.networknt.handler.Handler;

--- a/server/src/test/java/com/networknt/server/Test1ShutdownHook.java
+++ b/server/src/test/java/com/networknt/server/Test1ShutdownHook.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 public class Test1ShutdownHook implements ShutdownHookProvider {

--- a/server/src/test/java/com/networknt/server/Test1StartupHook.java
+++ b/server/src/test/java/com/networknt/server/Test1StartupHook.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 public class Test1StartupHook implements StartupHookProvider {

--- a/server/src/test/java/com/networknt/server/Test2MiddlewareHandler.java
+++ b/server/src/test/java/com/networknt/server/Test2MiddlewareHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 import com.networknt.handler.Handler;

--- a/server/src/test/java/com/networknt/server/Test2ShutdownHook.java
+++ b/server/src/test/java/com/networknt/server/Test2ShutdownHook.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 public class Test2ShutdownHook implements ShutdownHookProvider {

--- a/server/src/test/java/com/networknt/server/Test2StartupHook.java
+++ b/server/src/test/java/com/networknt/server/Test2StartupHook.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 public class Test2StartupHook implements StartupHookProvider {

--- a/server/src/test/java/com/networknt/server/TestHandler.java
+++ b/server/src/test/java/com/networknt/server/TestHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 import com.networknt.handler.LightHttpHandler;

--- a/server/src/test/java/com/networknt/server/TestHandlerProvider.java
+++ b/server/src/test/java/com/networknt/server/TestHandlerProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 import com.networknt.handler.HandlerProvider;

--- a/server/src/test/java/com/networknt/server/TestServer.java
+++ b/server/src/test/java/com/networknt/server/TestServer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.server;
 
 import org.junit.rules.ExternalResource;

--- a/server/src/test/resources/logback-test.xml
+++ b/server/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="error">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="info">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/service/src/main/java/com/networknt/service/ServiceConfig.java
+++ b/service/src/main/java/com/networknt/service/ServiceConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 import java.util.List;

--- a/service/src/main/java/com/networknt/service/ServiceUtil.java
+++ b/service/src/main/java/com/networknt/service/ServiceUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 import java.beans.Introspector;

--- a/service/src/main/java/com/networknt/service/SingletonServiceFactory.java
+++ b/service/src/main/java/com/networknt/service/SingletonServiceFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 import com.networknt.config.Config;

--- a/service/src/test/java/com/networknt/service/A.java
+++ b/service/src/test/java/com/networknt/service/A.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/AImpl.java
+++ b/service/src/test/java/com/networknt/service/AImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/B.java
+++ b/service/src/test/java/com/networknt/service/B.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/BImpl.java
+++ b/service/src/test/java/com/networknt/service/BImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/BTestImpl.java
+++ b/service/src/test/java/com/networknt/service/BTestImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/C.java
+++ b/service/src/test/java/com/networknt/service/C.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/CImpl.java
+++ b/service/src/test/java/com/networknt/service/CImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/ChannelMapping.java
+++ b/service/src/test/java/com/networknt/service/ChannelMapping.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public interface ChannelMapping {

--- a/service/src/test/java/com/networknt/service/ClassWithoutDefaultConstructor.java
+++ b/service/src/test/java/com/networknt/service/ClassWithoutDefaultConstructor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/Contact.java
+++ b/service/src/test/java/com/networknt/service/Contact.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public interface Contact {

--- a/service/src/test/java/com/networknt/service/ContactImpl.java
+++ b/service/src/test/java/com/networknt/service/ContactImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public class ContactImpl implements Contact {

--- a/service/src/test/java/com/networknt/service/ContactValidator.java
+++ b/service/src/test/java/com/networknt/service/ContactValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public class ContactValidator extends ValidatorBase<Contact> {

--- a/service/src/test/java/com/networknt/service/D1.java
+++ b/service/src/test/java/com/networknt/service/D1.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/D2.java
+++ b/service/src/test/java/com/networknt/service/D2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/DImpl.java
+++ b/service/src/test/java/com/networknt/service/DImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/DefaultChannelMapping.java
+++ b/service/src/test/java/com/networknt/service/DefaultChannelMapping.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 import java.util.HashMap;

--- a/service/src/test/java/com/networknt/service/Dummy.java
+++ b/service/src/test/java/com/networknt/service/Dummy.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public interface Dummy {

--- a/service/src/test/java/com/networknt/service/E.java
+++ b/service/src/test/java/com/networknt/service/E.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/EF1Impl.java
+++ b/service/src/test/java/com/networknt/service/EF1Impl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/EF2Impl.java
+++ b/service/src/test/java/com/networknt/service/EF2Impl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/F.java
+++ b/service/src/test/java/com/networknt/service/F.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/G.java
+++ b/service/src/test/java/com/networknt/service/G.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/GImpl.java
+++ b/service/src/test/java/com/networknt/service/GImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/Info.java
+++ b/service/src/test/java/com/networknt/service/Info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public interface Info {

--- a/service/src/test/java/com/networknt/service/InfoImpl.java
+++ b/service/src/test/java/com/networknt/service/InfoImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public class InfoImpl implements Info {

--- a/service/src/test/java/com/networknt/service/InfoValidator.java
+++ b/service/src/test/java/com/networknt/service/InfoValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public class InfoValidator extends ValidatorBase<Info> {

--- a/service/src/test/java/com/networknt/service/InjectedBean.java
+++ b/service/src/test/java/com/networknt/service/InjectedBean.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/IntegrationData.java
+++ b/service/src/test/java/com/networknt/service/IntegrationData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public class IntegrationData {

--- a/service/src/test/java/com/networknt/service/J.java
+++ b/service/src/test/java/com/networknt/service/J.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/JK1Impl.java
+++ b/service/src/test/java/com/networknt/service/JK1Impl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/JK2Impl.java
+++ b/service/src/test/java/com/networknt/service/JK2Impl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/K.java
+++ b/service/src/test/java/com/networknt/service/K.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/L.java
+++ b/service/src/test/java/com/networknt/service/L.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 import java.util.Map;

--- a/service/src/test/java/com/networknt/service/LImpl.java
+++ b/service/src/test/java/com/networknt/service/LImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 import java.util.Map;

--- a/service/src/test/java/com/networknt/service/License.java
+++ b/service/src/test/java/com/networknt/service/License.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public interface License {

--- a/service/src/test/java/com/networknt/service/LicenseImpl.java
+++ b/service/src/test/java/com/networknt/service/LicenseImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public class LicenseImpl implements License {

--- a/service/src/test/java/com/networknt/service/LicenseValidator.java
+++ b/service/src/test/java/com/networknt/service/LicenseValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public class LicenseValidator extends ValidatorBase<License> {

--- a/service/src/test/java/com/networknt/service/M.java
+++ b/service/src/test/java/com/networknt/service/M.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/MImpl.java
+++ b/service/src/test/java/com/networknt/service/MImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/Processor.java
+++ b/service/src/test/java/com/networknt/service/Processor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/ProcessorAImpl.java
+++ b/service/src/test/java/com/networknt/service/ProcessorAImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/ProcessorBImpl.java
+++ b/service/src/test/java/com/networknt/service/ProcessorBImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/ProcessorCImpl.java
+++ b/service/src/test/java/com/networknt/service/ProcessorCImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 /**

--- a/service/src/test/java/com/networknt/service/ServiceConfigTest.java
+++ b/service/src/test/java/com/networknt/service/ServiceConfigTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 import com.networknt.config.Config;

--- a/service/src/test/java/com/networknt/service/ServiceInitializer.java
+++ b/service/src/test/java/com/networknt/service/ServiceInitializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public class ServiceInitializer {

--- a/service/src/test/java/com/networknt/service/SingletonServiceFactoryTest.java
+++ b/service/src/test/java/com/networknt/service/SingletonServiceFactoryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 import org.junit.Assert;

--- a/service/src/test/java/com/networknt/service/TestServiceUtil.java
+++ b/service/src/test/java/com/networknt/service/TestServiceUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 import org.junit.Assert;

--- a/service/src/test/java/com/networknt/service/Validator.java
+++ b/service/src/test/java/com/networknt/service/Validator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public interface Validator<T> {

--- a/service/src/test/java/com/networknt/service/ValidatorBase.java
+++ b/service/src/test/java/com/networknt/service/ValidatorBase.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.service;
 
 public abstract class ValidatorBase<T> implements Validator<T> {

--- a/service/src/test/resources/logback-test.xml
+++ b/service/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/status/src/main/java/com/networknt/exception/FrameworkException.java
+++ b/status/src/main/java/com/networknt/exception/FrameworkException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.exception;
 
 import com.networknt.status.Status;

--- a/status/src/test/java/com/networknt/status/ErrorRootStatusSerializer.java
+++ b/status/src/test/java/com/networknt/status/ErrorRootStatusSerializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.status;
 
 /**

--- a/status/src/test/java/com/networknt/status/SeparateClassloaderTestRunner.java
+++ b/status/src/test/java/com/networknt/status/SeparateClassloaderTestRunner.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.status;
 
 import org.junit.runners.BlockJUnit4ClassRunner;

--- a/status/src/test/java/com/networknt/status/StatusSerializerTest.java
+++ b/status/src/test/java/com/networknt/status/StatusSerializerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.status;
 
 import com.networknt.config.Config;

--- a/status/src/test/resources/logback-test.xml
+++ b/status/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/switcher/src/main/java/com/networknt/switcher/SwitcherListener.java
+++ b/switcher/src/main/java/com/networknt/switcher/SwitcherListener.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package com.networknt.switcher;
 
 /**

--- a/switcher/src/test/resources/logback-test.xml
+++ b/switcher/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/traceability/src/test/resources/logback-test.xml
+++ b/traceability/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,35 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n
-            </pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB
-            </maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout"/>
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/utility/src/main/java/com/networknt/utility/CodeVerifierUtil.java
+++ b/utility/src/main/java/com/networknt/utility/CodeVerifierUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.utility;
 
 import org.slf4j.Logger;

--- a/utility/src/main/java/com/networknt/utility/CollectionUtil.java
+++ b/utility/src/main/java/com/networknt/utility/CollectionUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.utility;
 
 import java.util.Collection;

--- a/utility/src/main/java/com/networknt/utility/DateUtil.java
+++ b/utility/src/main/java/com/networknt/utility/DateUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.utility;
 
 import java.time.Instant;

--- a/utility/src/main/java/com/networknt/utility/Decryptor.java
+++ b/utility/src/main/java/com/networknt/utility/Decryptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.utility;
 
 public interface Decryptor {

--- a/utility/src/main/java/com/networknt/utility/FingerPrintUtil.java
+++ b/utility/src/main/java/com/networknt/utility/FingerPrintUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.utility;
 
 import org.slf4j.Logger;

--- a/utility/src/main/java/com/networknt/utility/HashUtil.java
+++ b/utility/src/main/java/com/networknt/utility/HashUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.utility;
 
 import org.apache.commons.codec.binary.Base64;

--- a/utility/src/main/java/com/networknt/utility/NioUtils.java
+++ b/utility/src/main/java/com/networknt/utility/NioUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.utility;
 
 import org.slf4j.Logger;

--- a/utility/src/main/java/com/networknt/utility/Tuple.java
+++ b/utility/src/main/java/com/networknt/utility/Tuple.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.utility;
 
 /**

--- a/utility/src/test/java/com/networknt/utility/CodeVerifierUtilTest.java
+++ b/utility/src/test/java/com/networknt/utility/CodeVerifierUtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.utility;
 
 import org.junit.Assert;

--- a/utility/src/test/java/com/networknt/utility/FingerPrintUtilTest.java
+++ b/utility/src/test/java/com/networknt/utility/FingerPrintUtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.utility;
 
 import com.networknt.config.Config;

--- a/utility/src/test/java/com/networknt/utility/HashUtilTest.java
+++ b/utility/src/test/java/com/networknt/utility/HashUtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.utility;
 
 import org.junit.Assert;

--- a/utility/src/test/java/com/networknt/utility/NioUtilsTest.java
+++ b/utility/src/test/java/com/networknt/utility/NioUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.utility;
 
 import org.junit.Test;

--- a/utility/src/test/java/com/networknt/utility/StringUtilsTest.java
+++ b/utility/src/test/java/com/networknt/utility/StringUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.utility;
 
 import org.junit.Assert;

--- a/utility/src/test/resources/logback-test.xml
+++ b/utility/src/test/resources/logback-test.xml
@@ -16,8 +16,6 @@
   -->
 
 <configuration>
-    TODO create logger for audit only.
-    http://stackoverflow.com/questions/2488558/logback-to-log-different-messages-to-two-files
     <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
         <Marker>PROFILER</Marker>
         <!--<OnMatch>DENY</OnMatch>-->
@@ -40,33 +38,12 @@
         </layout>
     </appender>
 
-    <!--audit log-->
-    <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>target/audit.log</file> <!-- logfile location -->
-        <encoder>
-            <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern> <!-- the layout pattern used to format log entries -->
-            <immediateFlush>true</immediateFlush>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>target/audit.log.%i.zip</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>5</maxIndex> <!-- max number of archived logs that are kept -->
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>200MB</maxFileSize> <!-- The size of the logfile that triggers a switch to a new logfile, and the current one archived -->
-        </triggeringPolicy>
-    </appender>
-
     <root level="trace">
         <appender-ref ref="stdout" />
     </root>
 
     <logger name="com.networknt" level="trace">
         <appender-ref ref="log"/>
-    </logger>
-
-    <logger name="Audit" level="trace" additivity="false">
-        <appender-ref ref="audit"/>
     </logger>
 
 </configuration>

--- a/zookeeper/src/main/java/com/networknt/zookeeper/ZkNodeType.java
+++ b/zookeeper/src/main/java/com/networknt/zookeeper/ZkNodeType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.zookeeper;
 
 /**

--- a/zookeeper/src/main/java/com/networknt/zookeeper/ZkUtils.java
+++ b/zookeeper/src/main/java/com/networknt/zookeeper/ZkUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.zookeeper;
 
 import com.networknt.status.Status;

--- a/zookeeper/src/main/java/com/networknt/zookeeper/client/ZooKeeperClient.java
+++ b/zookeeper/src/main/java/com/networknt/zookeeper/client/ZooKeeperClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.zookeeper.client;
 
 import org.I0Itec.zkclient.IZkChildListener;

--- a/zookeeper/src/main/java/com/networknt/zookeeper/client/ZooKeeperClientImpl.java
+++ b/zookeeper/src/main/java/com/networknt/zookeeper/client/ZooKeeperClientImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.zookeeper.client;
 
 import org.I0Itec.zkclient.IZkChildListener;

--- a/zookeeper/src/test/java/com/networknt/zookeeper/ZooKeeperRegistryTest.java
+++ b/zookeeper/src/test/java/com/networknt/zookeeper/ZooKeeperRegistryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.networknt.zookeeper;
 
 import com.networknt.registry.Registry;


### PR DESCRIPTION
1. add missing license info
Please review carefully io.dropwizards package in metrics/ module, there are still some files I don't know license to add

This is the first step to prepare adding apache rat plugin to auto check license header for light-4j project.

2. remove unused logback setting