### PR TITLE
Fix/#415 dynamic port binding

### DIFF
--- a/config/src/main/java/com/networknt/config/Config.java
+++ b/config/src/main/java/com/networknt/config/Config.java
@@ -43,7 +43,6 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public abstract class Config {
     public static final String LIGHT_4J_CONFIG_DIR = "light-4j-config-dir";
-    public enum InternalizedConfigPath {DEFAULT, CLASSPATH}
 
     protected Config() {
     }
@@ -338,36 +337,6 @@ public abstract class Config {
                     logger.info("Config loaded from default folder for " + Encode.forJava(configFilename));
                 }
                 return inStream;
-            }
-            if (configFilename.endsWith(CONFIG_EXT_YML)) {
-                logger.info("Unable to load config " + Encode.forJava(configFilename) + ". Looking for the same file name with extension yaml...");
-            } else if (configFilename.endsWith(CONFIG_EXT_YAML)) {
-                logger.info("Unable to load config " + Encode.forJava(configFilename) + ". Looking for the same file name with extension json...");
-            } else {
-                System.out.println("Unable to load config '" + Encode.forJava(configFilename.substring(0, configFilename.indexOf("."))) + "' with extension yml, yaml and json from external config, application config and module config. Please ignore this message if you are sure that your application is not using this config file.");
-            }
-            return null;
-        }
-
-        // overload method used to get config stream from classpath or default
-        private InputStream getConfigStream(String configFilename, InternalizedConfigPath path) {
-            InputStream inStream = null;
-            if (path.equals(InternalizedConfigPath.CLASSPATH)) {
-                inStream = getClass().getClassLoader().getResourceAsStream(configFilename);
-                if (inStream != null) {
-                    if (logger.isInfoEnabled()) {
-                        logger.info("config loaded from classpath for " + Encode.forJava(configFilename));
-                    }
-                    return inStream;
-                }
-            } else if (path.equals(InternalizedConfigPath.DEFAULT)) {
-                inStream = getClass().getClassLoader().getResourceAsStream("config/" + configFilename);
-                if (inStream != null) {
-                    if (logger.isInfoEnabled()) {
-                        logger.info("Config loaded from default folder for " + Encode.forJava(configFilename));
-                    }
-                    return inStream;
-                }
             }
             if (configFilename.endsWith(CONFIG_EXT_YML)) {
                 logger.info("Unable to load config " + Encode.forJava(configFilename) + ". Looking for the same file name with extension yaml...");

--- a/config/src/main/java/com/networknt/config/Config.java
+++ b/config/src/main/java/com/networknt/config/Config.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public abstract class Config {
     public static final String LIGHT_4J_CONFIG_DIR = "light-4j-config-dir";
+    public enum InternalizedConfigPath {DEFAULT, CLASSPATH}
 
     protected Config() {
     }
@@ -337,6 +338,36 @@ public abstract class Config {
                     logger.info("Config loaded from default folder for " + Encode.forJava(configFilename));
                 }
                 return inStream;
+            }
+            if (configFilename.endsWith(CONFIG_EXT_YML)) {
+                logger.info("Unable to load config " + Encode.forJava(configFilename) + ". Looking for the same file name with extension yaml...");
+            } else if (configFilename.endsWith(CONFIG_EXT_YAML)) {
+                logger.info("Unable to load config " + Encode.forJava(configFilename) + ". Looking for the same file name with extension json...");
+            } else {
+                System.out.println("Unable to load config '" + Encode.forJava(configFilename.substring(0, configFilename.indexOf("."))) + "' with extension yml, yaml and json from external config, application config and module config. Please ignore this message if you are sure that your application is not using this config file.");
+            }
+            return null;
+        }
+
+        // overload method used to get config stream from classpath or default
+        private InputStream getConfigStream(String configFilename, InternalizedConfigPath path) {
+            InputStream inStream = null;
+            if (path.equals(InternalizedConfigPath.CLASSPATH)) {
+                inStream = getClass().getClassLoader().getResourceAsStream(configFilename);
+                if (inStream != null) {
+                    if (logger.isInfoEnabled()) {
+                        logger.info("config loaded from classpath for " + Encode.forJava(configFilename));
+                    }
+                    return inStream;
+                }
+            } else if (path.equals(InternalizedConfigPath.DEFAULT)) {
+                inStream = getClass().getClassLoader().getResourceAsStream("config/" + configFilename);
+                if (inStream != null) {
+                    if (logger.isInfoEnabled()) {
+                        logger.info("Config loaded from default folder for " + Encode.forJava(configFilename));
+                    }
+                    return inStream;
+                }
             }
             if (configFilename.endsWith(CONFIG_EXT_YML)) {
                 logger.info("Unable to load config " + Encode.forJava(configFilename) + ". Looking for the same file name with extension yaml...");

--- a/server/src/main/java/com/networknt/server/Server.java
+++ b/server/src/main/java/com/networknt/server/Server.java
@@ -160,6 +160,12 @@ public class Server {
         }
 
         if (config.dynamicPort) {
+            if (config.minPort >= config.maxPort) {
+                String errMessage = "No ports available to bind to - the minPort is larger than or equal to the maxPort in server.yml";
+                System.out.println(errMessage);
+                logger.error(errMessage);
+                throw new RuntimeException(errMessage);
+            }
             for (int i = config.minPort; i < config.maxPort; i++) {
                 boolean b = bind(gracefulShutdownHandler, i);
                 if (b) {

--- a/server/src/main/java/com/networknt/server/Server.java
+++ b/server/src/main/java/com/networknt/server/Server.java
@@ -160,13 +160,13 @@ public class Server {
         }
 
         if (config.dynamicPort) {
-            if (config.minPort >= config.maxPort) {
-                String errMessage = "No ports available to bind to - the minPort is larger than or equal to the maxPort in server.yml";
+            if (config.minPort > config.maxPort) {
+                String errMessage = "No ports available to bind to - the minPort is larger than the maxPort in server.yml";
                 System.out.println(errMessage);
                 logger.error(errMessage);
                 throw new RuntimeException(errMessage);
             }
-            for (int i = config.minPort; i < config.maxPort; i++) {
+            for (int i = config.minPort; i <= config.maxPort; i++) {
                 boolean b = bind(gracefulShutdownHandler, i);
                 if (b) {
                     break;


### PR DESCRIPTION
@NicholasAzar @stevehu Hey! I am sorry that I have not fulfilled my duties to complete the task you handed in. I just did a test and found that there may still be some areas to improve on this issue.

I just did a manual test of develop branch and found the following problems:

If the user is using a static port and the port happens to be occupied, the user will get the following information:

Fail to bind to port 8453, trying 8454

And at this point the server does not stop, perhaps this will make the user mistakenly think that the server is always trying to bind the port. I think we should let the exception throw at the moment. 

Then, I test @NicholasAzar changes. due to the whole bind() is put in to try catch block, the registration exception would be caught by outer try-catch and the user would get the port bind fail message when the registration fails.

In summary, I made some changes to make sure the following performance:
1. (dynamic port) keep trying until reach valid port. If registration fails, the server stop after tried the first port.
2. (static port) trying to bind port. If fail, throw the exception. 

Related topics:
https://github.com/networknt/light-4j/pull/416
https://github.com/networknt/light-4j/issues/415