### PR TITLE
Added new server option ALLOW_UNESCAPED_CHARACTERS_IN_URL

### DIFF
--- a/server/src/main/java/com/networknt/server/Server.java
+++ b/server/src/main/java/com/networknt/server/Server.java
@@ -244,6 +244,7 @@ public class Server {
                     // HTTP/1.1 requests, as it is not required
                     .setServerOption(UndertowOptions.ALWAYS_SET_DATE, config.isAlwaysSetDate())
                     .setServerOption(UndertowOptions.RECORD_REQUEST_START_TIME, false)
+                    .setServerOption(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, config.isAllowUnescapedCharactersInUrl())
                     .setHandler(Handlers.header(handler, Headers.SERVER_STRING, config.getServerString())).setWorkerThreads(config.getWorkerThreads()).build();
 
             server.start();

--- a/server/src/main/java/com/networknt/server/ServerConfig.java
+++ b/server/src/main/java/com/networknt/server/ServerConfig.java
@@ -44,6 +44,7 @@ public class ServerConfig {
     int workerThreads;
     int backlog;
     boolean alwaysSetDate;
+    boolean allowUnescapedCharactersInUrl;
     String serverString;
 
     public ServerConfig() {
@@ -243,5 +244,13 @@ public class ServerConfig {
 
     public void setServerString(String serverString) {
         this.serverString = serverString;
+    }
+
+    public boolean isAllowUnescapedCharactersInUrl() {
+        return allowUnescapedCharactersInUrl;
+    }
+
+    public void setAllowUnescapedCharactersInUrl(boolean allowUnescapedCharactersInUrl) {
+        this.allowUnescapedCharactersInUrl = allowUnescapedCharactersInUrl;
     }
 }

--- a/server/src/main/java/com/networknt/server/ServerOption.java
+++ b/server/src/main/java/com/networknt/server/ServerOption.java
@@ -21,7 +21,8 @@ public enum ServerOption {
     BUFFER_SIZE("bufferSize"),
     BACKLOG("backlog"),
     SERVER_STRING("serverString"),
-    ALWAYS_SET_DATE("alwaysSetDate");
+    ALWAYS_SET_DATE("alwaysSetDate"),
+    ALLOW_UNESCAPED_CHARACTERS_IN_URL("allowUnescapedCharactersInUrl");
 
     private final String value;
 
@@ -92,6 +93,11 @@ public enum ServerOption {
             case ALWAYS_SET_DATE:
                 if (value == null) {
                     serverConfig.setAlwaysSetDate(true);
+                }
+                return true;
+            case ALLOW_UNESCAPED_CHARACTERS_IN_URL:
+                if (value == null) {
+                    serverConfig.setAllowUnescapedCharactersInUrl(true);
                 }
                 return true;
             default:

--- a/server/src/main/java/com/networknt/server/ServerOption.java
+++ b/server/src/main/java/com/networknt/server/ServerOption.java
@@ -97,7 +97,7 @@ public enum ServerOption {
                 return true;
             case ALLOW_UNESCAPED_CHARACTERS_IN_URL:
                 if (value == null) {
-                    serverConfig.setAllowUnescapedCharactersInUrl(true);
+                    serverConfig.setAllowUnescapedCharactersInUrl(false);
                 }
                 return true;
             default:

--- a/server/src/test/java/com/networknt/server/ServerConfigTest.java
+++ b/server/src/test/java/com/networknt/server/ServerConfigTest.java
@@ -59,7 +59,7 @@ public class ServerConfigTest {
         Assert.assertEquals(10000, serverConfig.getBacklog());
         Assert.assertEquals(false, serverConfig.isAlwaysSetDate());
         Assert.assertEquals("L", serverConfig.getServerString());
-        Assert.assertEquals(true, serverConfig.isAllowUnescapedCharactersInUrl());
+        Assert.assertEquals(false, serverConfig.isAllowUnescapedCharactersInUrl());
     }
 
     @Test
@@ -73,6 +73,6 @@ public class ServerConfigTest {
         Assert.assertEquals(10000, serverConfig.getBacklog());
         Assert.assertEquals(false, serverConfig.isAlwaysSetDate());
         Assert.assertEquals("TEST", serverConfig.getServerString());
-        Assert.assertEquals(false, serverConfig.isAllowUnescapedCharactersInUrl());
+        Assert.assertEquals(true, serverConfig.isAllowUnescapedCharactersInUrl());
     }
 }

--- a/server/src/test/java/com/networknt/server/ServerConfigTest.java
+++ b/server/src/test/java/com/networknt/server/ServerConfigTest.java
@@ -59,6 +59,7 @@ public class ServerConfigTest {
         Assert.assertEquals(10000, serverConfig.getBacklog());
         Assert.assertEquals(false, serverConfig.isAlwaysSetDate());
         Assert.assertEquals("L", serverConfig.getServerString());
+        Assert.assertEquals(true, serverConfig.isAllowUnescapedCharactersInUrl());
     }
 
     @Test
@@ -72,5 +73,6 @@ public class ServerConfigTest {
         Assert.assertEquals(10000, serverConfig.getBacklog());
         Assert.assertEquals(false, serverConfig.isAlwaysSetDate());
         Assert.assertEquals("TEST", serverConfig.getServerString());
+        Assert.assertEquals(false, serverConfig.isAllowUnescapedCharactersInUrl());
     }
 }

--- a/server/src/test/resources/config/server_valid_option.yml
+++ b/server/src/test/resources/config/server_valid_option.yml
@@ -4,4 +4,4 @@ workerThreads: 100
 backlog: 10000
 alwaysSetDate: false
 serverString: TEST
-allowUnescapedCharactersInUrl: false
+allowUnescapedCharactersInUrl: true

--- a/server/src/test/resources/config/server_valid_option.yml
+++ b/server/src/test/resources/config/server_valid_option.yml
@@ -4,3 +4,4 @@ workerThreads: 100
 backlog: 10000
 alwaysSetDate: false
 serverString: TEST
+allowUnescapedCharactersInUrl: false


### PR DESCRIPTION
related issue: https://github.com/networknt/light-4j/issues/412

Added new server option `allowUnescapedCharactersInUrl` to support new feature of undertow. It can be configured just like other server options (ioThread, workerThread...). The default value of it is `true`. The documentation will be updated later.