### PR TITLE
Feat/default decryptor

### DIFF
--- a/client/src/main/java/com/networknt/client/oauth/TokenManager.java
+++ b/client/src/main/java/com/networknt/client/oauth/TokenManager.java
@@ -8,7 +8,10 @@ import com.networknt.monad.Result;
 import io.undertow.client.ClientRequest;
 import io.undertow.util.HeaderValues;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This class is a singleton to manage ALL tokens.
@@ -101,7 +104,10 @@ public class TokenManager {
     public Result<Jwt> getJwt(ClientRequest clientRequest) {
         HeaderValues scope = clientRequest.getRequestHeaders().get(OauthHelper.SCOPE);
         if(scope != null) {
-            return getJwt(new Jwt.Key(scope.getFirst()));
+            String scopeStr = scope.getFirst();
+            Set<String> scopeSet = new HashSet<>();
+            scopeSet.addAll(Arrays.asList(scopeStr.split(" ")));
+            return getJwt(new Jwt.Key(scopeSet));
         }
         HeaderValues serviceId = clientRequest.getRequestHeaders().get(OauthHelper.SERVICE_ID);
         if(serviceId != null) {

--- a/config/src/main/java/com/networknt/config/Config.java
+++ b/config/src/main/java/com/networknt/config/Config.java
@@ -172,12 +172,12 @@ public abstract class Config {
         			logger.debug("found decryptorClass={}", decryptorClass);
         		}
         		
-        		return decryptorClass;
+        		return decryptorClass == null ? DecryptConstructor.DEFAULT_DECRYPTOR_CLASS : decryptorClass;
         	}else {
         		logger.warn("config file cannot be found.");
         	}
         	
-        	return null;
+        	return DecryptConstructor.DEFAULT_DECRYPTOR_CLASS;
         }
 
         private static Config initialize() {


### PR DESCRIPTION
Previous behaviour: when no decrypt class specify in config.yaml. No decryption apply

Change to: when no decryptor class specify in config.yml or no config.yml at all. Using AESDecryptor as the default. In this way. the backwards compatibility is maintained. 