### PR TITLE
Feat/#521 enbale http2 consul config

### DIFF
--- a/client/src/main/java/com/networknt/client/oauth/TokenManager.java
+++ b/client/src/main/java/com/networknt/client/oauth/TokenManager.java
@@ -8,7 +8,10 @@ import com.networknt.monad.Result;
 import io.undertow.client.ClientRequest;
 import io.undertow.util.HeaderValues;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This class is a singleton to manage ALL tokens.
@@ -101,7 +104,10 @@ public class TokenManager {
     public Result<Jwt> getJwt(ClientRequest clientRequest) {
         HeaderValues scope = clientRequest.getRequestHeaders().get(OauthHelper.SCOPE);
         if(scope != null) {
-            return getJwt(new Jwt.Key(scope.getFirst()));
+            String scopeStr = scope.getFirst();
+            Set<String> scopeSet = new HashSet<>();
+            scopeSet.addAll(Arrays.asList(scopeStr.split(" ")));
+            return getJwt(new Jwt.Key(scopeSet));
         }
         HeaderValues serviceId = clientRequest.getRequestHeaders().get(OauthHelper.SERVICE_ID);
         if(serviceId != null) {

--- a/consul/src/main/java/com/networknt/consul/ConsulConfig.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulConfig.java
@@ -25,6 +25,7 @@ public class ConsulConfig {
     boolean tcpCheck;
     boolean httpCheck;
     boolean ttlCheck;
+    boolean enbaleHttp2;
     String wait;
 
     public String getConsulUrl() {
@@ -84,5 +85,13 @@ public class ConsulConfig {
 
     public void setWait(String wait) {
         this.wait = wait;
+    }
+
+    public boolean isEnbaleHttp2() {
+        return enbaleHttp2;
+    }
+
+    public void setEnbaleHttp2(boolean enbaleHttp2) {
+        this.enbaleHttp2 = enbaleHttp2;
     }
 }

--- a/consul/src/main/java/com/networknt/consul/ConsulConfig.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulConfig.java
@@ -25,7 +25,7 @@ public class ConsulConfig {
     boolean tcpCheck;
     boolean httpCheck;
     boolean ttlCheck;
-    boolean enbaleHttp2;
+    boolean enableHttp2;
     String wait;
 
     public String getConsulUrl() {
@@ -87,11 +87,11 @@ public class ConsulConfig {
         this.wait = wait;
     }
 
-    public boolean isEnbaleHttp2() {
-        return enbaleHttp2;
+    public boolean isEnableHttp2() {
+        return enableHttp2;
     }
 
-    public void setEnbaleHttp2(boolean enbaleHttp2) {
-        this.enbaleHttp2 = enbaleHttp2;
+    public void setEnableHttp2(boolean enableHttp2) {
+        this.enableHttp2 = enableHttp2;
     }
 }

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
@@ -24,7 +24,6 @@ import com.networknt.consul.ConsulConstants;
 import com.networknt.consul.ConsulResponse;
 import com.networknt.consul.ConsulService;
 import com.networknt.httpstring.HttpStringConstants;
-import com.networknt.utility.Constants;
 import io.undertow.UndertowOptions;
 import io.undertow.client.ClientConnection;
 import io.undertow.client.ClientRequest;
@@ -74,7 +73,7 @@ public class ConsulClientImpl implements ConsulClient {
 	public ConsulClientImpl() {
 		// Will use http/2 connection if tls is enabled as Consul only support HTTP/2 with TLS.
 		String consulUrl = config.getConsulUrl().toLowerCase();
-		optionMap =  consulUrl.startsWith("https") ? OptionMap.create(UndertowOptions.ENABLE_HTTP2, true) : OptionMap.EMPTY;
+		optionMap =  config.isEnbaleHttp2() ? OptionMap.create(UndertowOptions.ENABLE_HTTP2, true) : OptionMap.EMPTY;
 		if(logger.isDebugEnabled()) logger.debug("url = " + consulUrl);
 		if(config.getWait() != null && config.getWait().length() > 2) wait = config.getWait();
 		if(logger.isDebugEnabled()) logger.debug("wait = " + wait);

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
@@ -73,7 +73,7 @@ public class ConsulClientImpl implements ConsulClient {
 	public ConsulClientImpl() {
 		// Will use http/2 connection if tls is enabled as Consul only support HTTP/2 with TLS.
 		String consulUrl = config.getConsulUrl().toLowerCase();
-		optionMap =  config.isEnbaleHttp2() ? OptionMap.create(UndertowOptions.ENABLE_HTTP2, true) : OptionMap.EMPTY;
+		optionMap =  config.isEnableHttp2() ? OptionMap.create(UndertowOptions.ENABLE_HTTP2, true) : OptionMap.EMPTY;
 		if(logger.isDebugEnabled()) logger.debug("url = " + consulUrl);
 		if(config.getWait() != null && config.getWait().length() > 2) wait = config.getWait();
 		if(logger.isDebugEnabled()) logger.debug("wait = " + wait);

--- a/consul/src/main/resources/config/consul.yml
+++ b/consul/src/main/resources/config/consul.yml
@@ -24,3 +24,5 @@ ttlCheck: true
 # This is limited to 10 minutes.This value can be specified in the form of "10s" or "5m" (i.e., 10 seconds or 5 minutes,
 # respectively).
 wait: 600s
+# enable HTTP/2
+enbaleHttp2: false

--- a/consul/src/main/resources/config/consul.yml
+++ b/consul/src/main/resources/config/consul.yml
@@ -25,4 +25,4 @@ ttlCheck: true
 # respectively).
 wait: 600s
 # enable HTTP/2
-enbaleHttp2: false
+enableHttp2: false


### PR DESCRIPTION
Related issue: https://github.com/networknt/light-4j/issues/521

Default value of enableHttp2 in consul.yml is false.

If no such entry in consul.yml, the value also be false.