### PR TITLE
Fix/npe service to url

### DIFF
--- a/cluster/src/main/java/com/networknt/cluster/LightCluster.java
+++ b/cluster/src/main/java/com/networknt/cluster/LightCluster.java
@@ -57,7 +57,7 @@ public class LightCluster implements Cluster {
      * @param protocol either http or https
      * @param serviceId unique service identifier
      * @param requestKey String
-     * @return Url discovered after the load balancing. Return null if the corresponding service cannot be discovered
+     * @return Url discovered after the load balancing. Return null if the corresponding service cannot be found
      */
     @Override
     public String serviceToUrl(String protocol, String serviceId, String tag, String requestKey) {
@@ -67,7 +67,7 @@ public class LightCluster implements Cluster {
             // construct a url in string
             return protocol + "://" + url.getHost() + ":" + url.getPort();
         } else {
-            logger.debug("The service: {} cannot be discovered.", serviceId);
+            logger.debug("The service: {} cannot be found from service discovery.", serviceId);
             return null;
         }
     }

--- a/cluster/src/main/java/com/networknt/cluster/LightCluster.java
+++ b/cluster/src/main/java/com/networknt/cluster/LightCluster.java
@@ -54,17 +54,22 @@ public class LightCluster implements Cluster {
     /**
      * Implement serviceToUrl with client side service discovery.
      *
-     * @param protocol String
-     * @param serviceId String
+     * @param protocol either http or https
+     * @param serviceId unique service identifier
      * @param requestKey String
-     * @return String
+     * @return Url discovered after the load balancing. Return null if the corresponding service cannot be discovered
      */
     @Override
     public String serviceToUrl(String protocol, String serviceId, String tag, String requestKey) {
         URL url = loadBalance.select(discovery(protocol, serviceId, tag), requestKey);
-        if(logger.isDebugEnabled()) logger.debug("final url after load balance = " + url);
-        // construct a url in string
-        return protocol + "://" + url.getHost() + ":" + url.getPort();
+        if (url != null) {
+            logger.debug("Final url after load balance = {}.", url);
+            // construct a url in string
+            return protocol + "://" + url.getHost() + ":" + url.getPort();
+        } else {
+            logger.debug("The service: {} cannot be discovered.", serviceId);
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
issue: https://github.com/networknt/light-4j/issues/518

A quick fix for LightCluster.serviceToUrl method, return null instead of NPE when the corresponding service cannot be found.