### PR TITLE
Fix/Replace "-" to "_" to match the OpenShift environment variable syntax

### DIFF
--- a/decryptor/src/main/java/com/networknt/decrypt/AutoAESDecryptor.java
+++ b/decryptor/src/main/java/com/networknt/decrypt/AutoAESDecryptor.java
@@ -9,7 +9,7 @@ package com.networknt.decrypt;
  * decryptorClass: com.networknt.decrypt.AutoAESDecryptor
  */
 public class AutoAESDecryptor extends AESDecryptor {
-    private final static String LIGHT_4J_CONFIG_PASSWORD = "light-4j-config-password";
+    private final static String LIGHT_4J_CONFIG_PASSWORD = "light_4j_config_password";
 
     @Override
     protected char[] getPassword() {


### PR DESCRIPTION
@stevehu Hi! Steve

My colleague @santoshaherkar found that the OpenShift doesn't support the key of environment variable contains "-". Therefore, I replaced them with "_". Do you know that is there any people using it right now? Can we include this change into the next release? Thanks!!