### PR TITLE
Make Http2Client.SSL public again, but deprecate it

### DIFF
--- a/client/src/main/java/com/networknt/client/Http2Client.java
+++ b/client/src/main/java/com/networknt/client/Http2Client.java
@@ -83,7 +83,12 @@ public class Http2Client {
             .set(Options.KEEP_ALIVE, true)
             .set(Options.WORKER_NAME, "Client").getMap();
     public static XnioWorker WORKER;
-    private static XnioSsl SSL;
+    /**
+     * @deprecated  As of release 1.6.11, replaced by {@link #getDefaultXnioSsl()}
+     *              SSL is no longer statically initialized.
+     */
+    @Deprecated
+    public static XnioSsl SSL;
     public static final AttachmentKey<String> RESPONSE_BODY = AttachmentKey.create(String.class);
 
     static final String TLS = "tls";


### PR DESCRIPTION
Due to the major impact of making Http2Client.SSL private, we elect to make it public again, but to deprecate it. See issue #629, and PR #630 for full details.