### PR TITLE
Bug fix: ConsulRegistry keeps the first service url discovered in cache

### DIFF
--- a/registry/src/main/java/com/networknt/registry/support/command/CommandFailbackRegistry.java
+++ b/registry/src/main/java/com/networknt/registry/support/command/CommandFailbackRegistry.java
@@ -72,7 +72,7 @@ public abstract class CommandFailbackRegistry extends FailbackRegistry {
         return finalResult;
     }
 
-    private CommandServiceManager getCommandServiceManager(URL urlCopy) {
+    protected CommandServiceManager getCommandServiceManager(URL urlCopy) {
         CommandServiceManager manager = commandManagerMap.get(urlCopy);
         if (manager == null) {
             manager = new CommandServiceManager(urlCopy);


### PR DESCRIPTION
Fix the [issue](https://github.com/networknt/light-4j/issues/632)