### PR TITLE
Issue #744: Valuemap not pickup the values loaded from config server

### DIFF
--- a/config/src/main/java/com/networknt/config/ConfigInjection.java
+++ b/config/src/main/java/com/networknt/config/ConfigInjection.java
@@ -50,7 +50,6 @@ public class ConfigInjection {
     private static final String EXCLUSION_CONFIG_FILE_LIST = "exclusionConfigFileList";
 
     private static final Map<String, Object> exclusionMap = Config.getInstance().getJsonMapConfig(SCALABLE_CONFIG);
-    private static final Map<String, Object> valueMap = Config.getInstance().getDefaultJsonMapConfig(CENTRALIZED_MANAGEMENT);
 
     // Define the injection pattern which represents the injection points
     private static Pattern pattern = Pattern.compile("\\$\\{(.*?)\\}");
@@ -93,6 +92,7 @@ public class ConfigInjection {
             Boolean containsField = false;
             // Use key of injectionPattern to get value from both environment variables and "values.yaml"
             Object envValue = typeCast(System.getenv(injectionPattern.getKey()));
+            Map<String, Object> valueMap = Config.getInstance().getDefaultJsonMapConfig(CENTRALIZED_MANAGEMENT);
             Object fileValue = (valueMap != null) ? valueMap.get(injectionPattern.getKey()) : null;
             // Return different value from different sources based on injection order defined before
             if ((INJECTION_ORDER_CODE.equals("2") && envValue != null) || (INJECTION_ORDER_CODE.equals("1") && fileValue == null)) {

--- a/config/src/test/java/com/networknt/config/ConfigInjectionTest.java
+++ b/config/src/test/java/com/networknt/config/ConfigInjectionTest.java
@@ -1,0 +1,39 @@
+package com.networknt.config;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ConfigInjectionTest {
+
+    private static final String value = "${valueKey}";
+    private static final String configKey = "valueKey";
+    private static final String configValue = "password";
+    private static final String valueMapKey = "values";
+    private static final Map<String, Object> valueMap = Config.getInstance().getDefaultJsonMapConfig(valueMapKey);
+
+    @Test
+    public void testGetInjectValueIssue744() {
+
+        Object oldConfigValue = null;
+        try {
+            oldConfigValue = ConfigInjection.getInjectValue(value);
+        } catch (Exception ce) {
+            // expected exception since no valuemap defined yet.
+            assertTrue(ce instanceof ConfigException);
+        }
+        assertNull(oldConfigValue);
+
+        Map<String, Object> newValueMap = new HashMap<>();
+        newValueMap.put(configKey, configValue);
+        Config.getInstance().putInConfigCache(valueMapKey, newValueMap);
+
+        Object newConfigValue = ConfigInjection.getInjectValue(value);
+
+        assertNotNull(newConfigValue);
+        assertEquals(configValue, newConfigValue);
+    }
+}


### PR DESCRIPTION
The previous commit caused this issue. We need to move the `valueMap `back to the `getValue `method.