### PR TITLE
Avoid NoSuchElementException in ManualAESDecryptor.

### DIFF
--- a/decryptor/src/main/java/com/networknt/decrypt/ManualAESDecryptor.java
+++ b/decryptor/src/main/java/com/networknt/decrypt/ManualAESDecryptor.java
@@ -21,7 +21,9 @@ public class ManualAESDecryptor extends AESDecryptor {
             // for IDE testing
             System.out.print("Password for config decryption: ");
             Scanner sc = new Scanner(System.in);
-            password = sc.next().toCharArray();
+            if (sc.hasNext()) {
+              password = sc.next().toCharArray();
+            }
             sc.close();
         }
         if (password == null || password.length == 0) {


### PR DESCRIPTION
An exception was possible if System.in was redirected to read an empty file.