### PR TITLE
Fixed flaky tests caused by SharedMetricRegistries in SharedMetricRegistriesTest.java

### DIFF
--- a/metrics/src/test/java/io/dropwizard/metrics/SharedMetricRegistriesTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/SharedMetricRegistriesTest.java
@@ -38,7 +38,7 @@ public class SharedMetricRegistriesTest {
                 .isEmpty();
     }
 	
-	@After
+    @After
     public void tearDown() {
         SharedMetricRegistries.clear();
 

--- a/metrics/src/test/java/io/dropwizard/metrics/SharedMetricRegistriesTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/SharedMetricRegistriesTest.java
@@ -31,20 +31,20 @@ import java.lang.reflect.Modifier;
 public class SharedMetricRegistriesTest {
     
     @Before
-	public void setUp() {
-		SharedMetricRegistries.clear();
+    public void setUp() {
+        SharedMetricRegistries.clear();
 
         assertThat(SharedMetricRegistries.names())
                 .isEmpty();
-	}
+    }
 	
 	@After
-	public void tearDown() {
-		SharedMetricRegistries.clear();
+    public void tearDown() {
+        SharedMetricRegistries.clear();
 
         assertThat(SharedMetricRegistries.names())
                 .isEmpty();
-	}
+    }
 
     @Test
     public void memorizesRegistriesByName() throws Exception {

--- a/metrics/src/test/java/io/dropwizard/metrics/SharedMetricRegistriesTest.java
+++ b/metrics/src/test/java/io/dropwizard/metrics/SharedMetricRegistriesTest.java
@@ -16,6 +16,7 @@
 
 package io.dropwizard.metrics;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,6 +29,22 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
 public class SharedMetricRegistriesTest {
+    
+    @Before
+	public void setUp() {
+		SharedMetricRegistries.clear();
+
+        assertThat(SharedMetricRegistries.names())
+                .isEmpty();
+	}
+	
+	@After
+	public void tearDown() {
+		SharedMetricRegistries.clear();
+
+        assertThat(SharedMetricRegistries.names())
+                .isEmpty();
+	}
 
     @Test
     public void memorizesRegistriesByName() throws Exception {


### PR DESCRIPTION
Fixed flaky test that caused by `io.dropwizard.metrics.SharedMetricRegistries` in class `SharedMetricRegistriesTest.java`. 

- **Issue 1** 
    - If only run `errorsWhenDefaultAlreadySet()` method before `hasASetOfNames()`method, the `hasASetOfNames()` will failed at https://github.com/networknt/light-4j/blob/fcded1683dcbd41a968e221494778aa6b71e7428/metrics/src/test/java/io/dropwizard/metrics/SharedMetricRegistriesTest.java#L45

    - error msg: 
    ```
        java.lang.AssertionError: 
        Expecting:
          <["one", "borg", "foobah"]>
        to contain only:
          <["one"]>
        but the following elements were unexpected:
          <["borg", "foobah"]>
    ```

- **Issue 2** 
    - If only run `errorsWhenDefaultAlreadySet()` method before `removesRegistries()`method, the `removesRegistries()` will failed at https://github.com/networknt/light-4j/blob/fcded1683dcbd41a968e221494778aa6b71e7428/metrics/src/test/java/io/dropwizard/metrics/SharedMetricRegistriesTest.java#L54

    - error msg: 
    ```
       java.lang.AssertionError: 
       Expecting:
         <["one", "foobah"]>
       to contain only:
         <["one"]>
       but the following elements were unexpected:
         <["foobah"]>
    ```
- **root cause**
    - The `SharedMetricRegistries` variable is not cleared after each tests. 

- **solution**: 
Added `setUp()` and `tearDown()` methods right before and after each tests to clear `SharedMetricRegistries`.

The flaky tests are found by running [iDFlakies](https://github.com/idflakies/iDFlakies), after fixing the issue, there's no flaky tests in `SharedMetricRegistriesTest.java`