### PR TITLE
issue-858

### DIFF
--- a/audit/pom.xml
+++ b/audit/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>handler</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>status</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
         </dependency>

--- a/audit/src/main/java/com/networknt/audit/AuditConfig.java
+++ b/audit/src/main/java/com/networknt/audit/AuditConfig.java
@@ -32,6 +32,7 @@ class AuditConfig {
     private static final String AUDIT_ON_ERROR = "auditOnError";
     private static final String IS_LOG_LEVEL_ERROR = "logLevelIsError";
     private static final String IS_MASK_ENABLED = "mask";
+    private static final String TIMESTAMP_FORMAT = "timestampFormat";
     private final Map<String, Object> mappedConfig;
     static final String CONFIG_NAME = "audit";
     private List<String> headerList;
@@ -44,6 +45,7 @@ class AuditConfig {
     private boolean responseTime;
     private boolean auditOnError;
     private boolean isMaskEnabled;
+    private String timestampFormat;
 
     private AuditConfig() {
         config = Config.getInstance();
@@ -98,6 +100,10 @@ class AuditConfig {
         return getAuditList() != null && getAuditList().size() > 0;
     }
 
+    String getTimestampFormat() {
+        return timestampFormat;
+    }
+
     Config getConfig() {
         return config;
     }
@@ -132,5 +138,6 @@ class AuditConfig {
         if(object != null && (Boolean) object) {
             isMaskEnabled = true;
         }
+        timestampFormat = (String)getMappedConfig().get(TIMESTAMP_FORMAT);
     }
 }

--- a/audit/src/main/resources/config/audit.yml
+++ b/audit/src/main/resources/config/audit.yml
@@ -20,7 +20,7 @@ auditOnError: false
 # log level; by default set to info
 logLevelIsError: false
 
-# the format for outputting the timestamp, if not specify, will use long value
+# the format for outputting the timestamp, if the format is not specified or invalid, will use a long value.
 #timestampFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZ
 
 # Output header elements. You can add more if you want.

--- a/audit/src/main/resources/config/audit.yml
+++ b/audit/src/main/resources/config/audit.yml
@@ -20,6 +20,8 @@ auditOnError: false
 # log level; by default set to info
 logLevelIsError: false
 
+# the format for outputting the timestamp, if not specify, will use long value
+#timestampFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZ
 
 # Output header elements. You can add more if you want.
 headers:

--- a/audit/src/test/java/com/networknt/audit/AuditConfigTest.java
+++ b/audit/src/test/java/com/networknt/audit/AuditConfigTest.java
@@ -64,6 +64,7 @@ public class AuditConfigTest {
         Assert.assertFalse(configHandler.isResponseTime());
         Assert.assertFalse(configHandler.isAuditOnError());
         Assert.assertFalse(configHandler.isMaskEnabled());
+        Assert.assertNull(configHandler.getTimestampFormat());
     }
 
     @Test
@@ -155,5 +156,23 @@ public class AuditConfigTest {
         configMap.put("logLevelIsError", typeOfValue);
         configMap.put("mask", typeOfValue);
         return configMap;
+    }
+
+    @Test
+    public void shouldGetTimestampFormatAndAuditConfig() {
+        HashMap<String, Object> configMap = new HashMap<>();
+        String format= "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+        configMap.put("timestampFormat", format);
+
+        Logger logger = Mockito.mock(Logger.class);
+        Mockito.when(LoggerFactory.getLogger(Constants.AUDIT_LOGGER)).thenReturn(logger);
+
+        Config config = Mockito.mock(Config.class);
+        Mockito.when(config.getJsonMapConfigNoCache(CONFIG_NAME)).thenReturn(configMap);
+        Mockito.when(Config.getInstance()).thenReturn(config);
+
+        AuditConfig configHandler = AuditConfig.load();
+
+        Assert.assertEquals(format, configHandler.getTimestampFormat());
     }
 }

--- a/audit/src/test/java/com/networknt/audit/AuditHandlerTest.java
+++ b/audit/src/test/java/com/networknt/audit/AuditHandlerTest.java
@@ -62,8 +62,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 /**
  * Created by steve on 01/09/16.
@@ -381,15 +380,48 @@ public class AuditHandlerTest {
         verifyAuditInfo("timestamp", "2020-12-10T17:30:11.945-0500");
     }
 
-/*    @Test used for testing when doesn't specify timestampFormat
+    @Test //used for testing when doesn't specify timestampFormat
     public void testAuditWith200TimestampLong() throws Exception {
-        long time = 1607639411945L;
+        Map<String, Object> map = testTimestampInitHelper(null);
+        Assert.assertEquals(1607639411945L, map.get("timestamp"));
+    }
 
+    @Test //used for testing when user specified a wrong format timestampFormat
+    public void testAuditWith200TimestampInvalidFormat() throws Exception {
+        Map<String, Object> map = testTimestampInitHelper("abc");
+        Assert.assertEquals(1607639411945L, map.get("timestamp"));
+    }
+
+    private Map<String, Object> testTimestampInitHelper(String o) throws Exception {
+        PowerMockito.mockStatic(AuditConfig.class);
+        AtomicReference<String> content = new AtomicReference<>("");
+        Consumer<String> consumer = (str) -> content.set(str);
+        // mock handler
+        AuditConfig auditConfig = Mockito.mock(AuditConfig.class);
+        when(auditConfig.getAuditFunc()).thenReturn(consumer);
+
+        Mockito.when(auditConfig.getTimestampFormat()).thenReturn(o);
+        Config config = Mockito.mock(Config.class);
+        when(config.getMapper()).thenReturn(new ObjectMapper());
+        Mockito.when(auditConfig.getConfig()).thenReturn(config);
+        PowerMockito.when(AuditConfig.load()).thenReturn(auditConfig);
+        AuditHandler auditHandler = Mockito.spy(new AuditHandler());
+        Mockito.doNothing().when(auditHandler).next(Mockito.any());
+
+        // mock exchange
+        HeaderMap headerMap = Mockito.spy(new HeaderMap());
+        HttpServerExchange httpServerExchange = Mockito.mock(HttpServerExchange.class);
+        Mockito.when(httpServerExchange.getRequestHeaders()).thenReturn(headerMap);
+
+        long time = 1607639411945L;
+        // mock time
         PowerMockito.mockStatic(System.class);
         PowerMockito.when(System.currentTimeMillis()).thenReturn(time);
-        runTest("/pet", "post", null, 200);
-        verifyAuditInfo("timestamp", "1607639411945");
-    }*/
+
+        Handler.init();
+        auditHandler.handleRequest(httpServerExchange);
+        return JsonMapper.string2Map(content.get());
+    }
 
     @Test
     public void shouldAddListenerIfIsStatusCodeAndIsResponseTimeAreTrue() throws Exception {

--- a/audit/src/test/resources/audit.yml
+++ b/audit/src/test/resources/audit.yml
@@ -20,6 +20,9 @@ auditOnError: false
 # log level; by default set to info
 logLevelIsError: false
 
+# the format for outputting the timestamp
+timestampFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZ
+
 
 # Output header elements. You can add more if you want.
 headers:

--- a/status/src/main/resources/config/status.yml
+++ b/status/src/main/resources/config/status.yml
@@ -422,6 +422,11 @@ ERR10059:
   code: ERR10059
   message: REQUEST_BODY_MISSING
   description: Request body is missing.
+ERR10060:
+  statusCode: 400
+  code: ERR10060
+  message: CONFIG_VALUE_INVALID
+  description: Config value %s for key %s invalid in config file %s.
 
 # 11000-11500 swagger-validator errors
 ERR11000:


### PR DESCRIPTION
- added timestampFormat in audit.yml, if timestampFormat is specified, then will use the format, 
if the format of the timestamp is invalid, it will use a long value.
- if the format is incorrect, it will show an error when the server starts up