### PR TITLE
Enhancing to use different env variables in different junit test classes

### DIFF
--- a/config/src/main/java/com/networknt/config/ConfigInjection.java
+++ b/config/src/main/java/com/networknt/config/ConfigInjection.java
@@ -96,7 +96,7 @@ public class ConfigInjection {
             // Flag to validate whether the environment or values.yml contains the corresponding field
             Boolean containsField = false;
             // Use key of injectionPattern to get value from both environment variables and "values.yaml"
-            Object envValue = typeCast(System.getenv(injectionPattern.getKey()));
+            Object envValue = typeCast(System.getenv().get(injectionPattern.getKey()));
             Map<String, Object> valueMap = Config.getInstance().getDefaultJsonMapConfig(CENTRALIZED_MANAGEMENT);
             Object fileValue = (valueMap != null) ? valueMap.get(injectionPattern.getKey()) : null;
             // Return different value from different sources based on injection order defined before


### PR DESCRIPTION
System.getenv() and System.getenv(String) uses ProcessEnvironment.getenv() and ProcessEnvironment.getenv(String) respectively. If you take a look at ProcessEnvironment.getenv() and ProcessEnvironment.getenv(String), you will find that they return different maps and because of that we may get different values when invoking both these methids. Hence changing line 99 in ConfigInjection to make it same as 110.

With this fix, I am able to set different environment variables in different junit test classes.

![image](https://user-images.githubusercontent.com/22718659/102844735-09b94380-43da-11eb-99e7-912203926a09.png)
