### PR TITLE
issue #894 show metadaata, description, message separately

### DIFF
--- a/handler/src/main/java/com/networknt/handler/LightHttpHandler.java
+++ b/handler/src/main/java/com/networknt/handler/LightHttpHandler.java
@@ -136,6 +136,7 @@ public interface LightHttpHandler extends HttpHandler {
         if (auditStackTrace) {
             auditInfo.put(Constants.STACK_TRACE, Arrays.toString(elements));
         }
-        exchange.getResponseSender().send(status.toString());
+        exchange.getResponseSender().send(
+                status.toStringConditionally(Status.shouldShowMessage(), Status.shouldShowDescription(), Status.shouldShowMetadata()));
     }
 }

--- a/handler/src/main/java/com/networknt/handler/LightHttpHandler.java
+++ b/handler/src/main/java/com/networknt/handler/LightHttpHandler.java
@@ -137,6 +137,6 @@ public interface LightHttpHandler extends HttpHandler {
             auditInfo.put(Constants.STACK_TRACE, Arrays.toString(elements));
         }
         exchange.getResponseSender().send(
-                status.toStringConditionally(Status.shouldShowMessage(), Status.shouldShowDescription(), Status.shouldShowMetadata()));
+                status.toStringConditionally());
     }
 }

--- a/status/src/main/java/com/networknt/status/Status.java
+++ b/status/src/main/java/com/networknt/status/Status.java
@@ -257,29 +257,22 @@ public class Status {
         if (statusSerializer != null) {
             return statusSerializer.serializeStatus(this);
         } else {
-            StringBuilder sb = new StringBuilder();
-            sb.append("{")
-                    .append("\"statusCode\":" + getStatusCode())
-                    .append(",\"code\":\"" + getCode())
-                    .append("\",\"message\":\"" + getMessage())
-                    .append("\",\"description\":\"" + getDescription());
-            if (getMetadata() != null) {
-                try {
-                    sb.append("\",\"metadata\":" + Config.getInstance().getMapper().writeValueAsString(getMetadata()));
-                } catch (JsonProcessingException e) {
-                    logger.error("cannot parse metadata for status:" + getStatusCode(), e);
-                }
-                sb.append(",\"severity\":\"" + getSeverity());
-            } else {
-                sb.append("\",\"severity\":\"" + getSeverity());
-            }
-            sb.append("\"}");
-
-            return sb.toString();
+            return toStringConditionally(true, true, true);
         }
     }
 
-    public String toStringConditionally(boolean showMessage, boolean showDescription, boolean showMetadata) {
+    /**
+     * This method is used to construct a Status with fields conditionally.
+     *
+     * @return JSON style String of Status
+     */
+    public String toStringConditionally() {
+
+        return toStringConditionally(shouldShowMessage(), shouldShowDescription(), shouldShowMetadata());
+    }
+
+    private String toStringConditionally(boolean showMessage, boolean showDescription, boolean showMetadata) {
+
         StringBuilder sb = new StringBuilder();
         sb.append("{")
                 .append("\"statusCode\":" + getStatusCode())

--- a/status/src/main/java/com/networknt/status/Status.java
+++ b/status/src/main/java/com/networknt/status/Status.java
@@ -298,7 +298,7 @@ public class Status {
         return sb.toString();
     }
 
-    private static Map<String, Object> getConfig() {
+    public static Map<String, Object> getConfig() {
         return Config.getInstance().getJsonMapConfig(CONFIG_NAME);
     }
 

--- a/status/src/test/java/com/networknt/status/StatusDefaultTest.java
+++ b/status/src/test/java/com/networknt/status/StatusDefaultTest.java
@@ -89,7 +89,7 @@ public class StatusDefaultTest {
         System.out.println(status);
         String expected = "{\"statusCode\":400,\"code\":\"ERR11000\",\"message\":\"VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING\",\"description\":\"Query parameter parameter name is required on path original url but not found in request.\",\"metadata\":{\"metaKey\":{\"nestedKey\":\"nestedValue\"}},\"severity\":\"ERROR\"}";
         ObjectMapper mapper = new ObjectMapper();
-        Assert.assertEquals(expected, status.toStringConditionally(true, true, true));
+        Assert.assertEquals(expected, status.toStringConditionally());
         HashMap<String, Object> deSerialized = mapper.readValue(expected, new TypeReference<HashMap<String, Object>>() {
         });
         Assert.assertEquals(deSerialized.get("statusCode"), 400);
@@ -111,7 +111,7 @@ public class StatusDefaultTest {
         System.out.println(status);
         String expected = "{\"statusCode\":400,\"code\":\"ERR11000\",\"message\":\"VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING\",\"description\":\"Query parameter parameter name is required on path original url but not found in request.\",\"metadata\":{\"metaKey\":{\"nestedKey\":\"nestedValue\"}},\"severity\":\"ERROR\"}";
         Assert.assertEquals(expected, status.toString());
-        Assert.assertEquals(status.toString(), status.toStringConditionally(true, true, true));
+        Assert.assertEquals(status.toString(), status.toStringConditionally());
     }
 
     @PrepareForTest({Config.class})
@@ -130,8 +130,8 @@ public class StatusDefaultTest {
         initStatusConfig(true, true, false);
 
         Status status = new Status("ERR11000", Map.of("metaKey", "metaValue"), "parameter name", "original url");
-        System.out.println(status.toStringConditionally(true, true, false));
-        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"message\":\"VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING\",\"description\":\"Query parameter parameter name is required on path original url but not found in request.\",\"severity\":\"ERROR\"}", status.toStringConditionally(true, true, false));
+        System.out.println(status.toStringConditionally());
+        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"message\":\"VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING\",\"description\":\"Query parameter parameter name is required on path original url but not found in request.\",\"severity\":\"ERROR\"}", status.toStringConditionally());
     }
 
     @PrepareForTest({Config.class})
@@ -141,7 +141,7 @@ public class StatusDefaultTest {
 
         Status status = new Status("ERR11000", Map.of("metaKey", "metaValue"), "parameter name", "original url");
         System.out.println(status);
-        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"description\":\"Query parameter parameter name is required on path original url but not found in request.\",\"metadata\":{\"metaKey\":\"metaValue\"},\"severity\":\"ERROR\"}", status.toStringConditionally(false, true, true));
+        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"description\":\"Query parameter parameter name is required on path original url but not found in request.\",\"metadata\":{\"metaKey\":\"metaValue\"},\"severity\":\"ERROR\"}", status.toStringConditionally());
     }
 
     @PrepareForTest({Config.class})
@@ -151,7 +151,7 @@ public class StatusDefaultTest {
 
         Status status = new Status("ERR11000", Map.of("metaKey", "metaValue"), "parameter name", "original url");
         System.out.println(status);
-        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"message\":\"VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING\",\"metadata\":{\"metaKey\":\"metaValue\"},\"severity\":\"ERROR\"}", status.toStringConditionally(true, false, true));
+        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"message\":\"VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING\",\"metadata\":{\"metaKey\":\"metaValue\"},\"severity\":\"ERROR\"}", status.toStringConditionally());
     }
 
     @PrepareForTest({Config.class})
@@ -161,7 +161,7 @@ public class StatusDefaultTest {
 
         Status status = new Status("ERR11000", Map.of("metaKey", "metaValue"), "parameter name", "original url");
         System.out.println(status);
-        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"severity\":\"ERROR\"}", status.toStringConditionally(false, false, false));
+        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"severity\":\"ERROR\"}", status.toStringConditionally());
     }
 
     private void initStatusConfig(boolean showMessage, boolean showDescription, boolean showMetadata) {

--- a/status/src/test/java/com/networknt/status/StatusDefaultTest.java
+++ b/status/src/test/java/com/networknt/status/StatusDefaultTest.java
@@ -89,7 +89,7 @@ public class StatusDefaultTest {
         System.out.println(status);
         String expected = "{\"statusCode\":400,\"code\":\"ERR11000\",\"message\":\"VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING\",\"description\":\"Query parameter parameter name is required on path original url but not found in request.\",\"metadata\":{\"metaKey\":{\"nestedKey\":\"nestedValue\"}},\"severity\":\"ERROR\"}";
         ObjectMapper mapper = new ObjectMapper();
-        Assert.assertEquals(expected, status.toString());
+        Assert.assertEquals(expected, status.toStringConditionally(true, true, true));
         HashMap<String, Object> deSerialized = mapper.readValue(expected, new TypeReference<HashMap<String, Object>>() {
         });
         Assert.assertEquals(deSerialized.get("statusCode"), 400);
@@ -100,6 +100,18 @@ public class StatusDefaultTest {
         Assert.assertNotNull(meta.get("metaKey"));
         Map<String, Object> nested = (Map<String, Object>) meta.get("metaKey");
         Assert.assertEquals(nested.get("nestedKey"), "nestedValue");
+    }
+
+    @PrepareForTest({Config.class})
+    @Test
+    public void testToStringWithEverything() throws JsonProcessingException {
+        initStatusConfig(true, true, true);
+
+        Status status = new Status("ERR11000", Map.of("metaKey", Map.of("nestedKey", "nestedValue")), "parameter name", "original url");
+        System.out.println(status);
+        String expected = "{\"statusCode\":400,\"code\":\"ERR11000\",\"message\":\"VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING\",\"description\":\"Query parameter parameter name is required on path original url but not found in request.\",\"metadata\":{\"metaKey\":{\"nestedKey\":\"nestedValue\"}},\"severity\":\"ERROR\"}";
+        Assert.assertEquals(expected, status.toString());
+        Assert.assertEquals(status.toString(), status.toStringConditionally(true, true, true));
     }
 
     @PrepareForTest({Config.class})
@@ -115,11 +127,11 @@ public class StatusDefaultTest {
     @PrepareForTest({Config.class})
     @Test
     public void testToStringWithoutMetadata() {
-        initStatusConfig(true, false, true);
+        initStatusConfig(true, true, false);
 
         Status status = new Status("ERR11000", Map.of("metaKey", "metaValue"), "parameter name", "original url");
-        System.out.println(status);
-        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"message\":\"VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING\",\"description\":\"Query parameter parameter name is required on path original url but not found in request.\",\"severity\":\"ERROR\"}", status.toString());
+        System.out.println(status.toStringConditionally(true, true, false));
+        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"message\":\"VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING\",\"description\":\"Query parameter parameter name is required on path original url but not found in request.\",\"severity\":\"ERROR\"}", status.toStringConditionally(true, true, false));
     }
 
     @PrepareForTest({Config.class})
@@ -129,17 +141,17 @@ public class StatusDefaultTest {
 
         Status status = new Status("ERR11000", Map.of("metaKey", "metaValue"), "parameter name", "original url");
         System.out.println(status);
-        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"description\":\"Query parameter parameter name is required on path original url but not found in request.\",\"metadata\":{\"metaKey\":\"metaValue\"},\"severity\":\"ERROR\"}", status.toString());
+        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"description\":\"Query parameter parameter name is required on path original url but not found in request.\",\"metadata\":{\"metaKey\":\"metaValue\"},\"severity\":\"ERROR\"}", status.toStringConditionally(false, true, true));
     }
 
     @PrepareForTest({Config.class})
     @Test
     public void testToStringWithoutDescription() {
-        initStatusConfig(true, true, false);
+        initStatusConfig(true, false, true);
 
         Status status = new Status("ERR11000", Map.of("metaKey", "metaValue"), "parameter name", "original url");
         System.out.println(status);
-        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"message\":\"VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING\",\"metadata\":{\"metaKey\":\"metaValue\"},\"severity\":\"ERROR\"}", status.toString());
+        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"message\":\"VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING\",\"metadata\":{\"metaKey\":\"metaValue\"},\"severity\":\"ERROR\"}", status.toStringConditionally(true, false, true));
     }
 
     @PrepareForTest({Config.class})
@@ -149,10 +161,10 @@ public class StatusDefaultTest {
 
         Status status = new Status("ERR11000", Map.of("metaKey", "metaValue"), "parameter name", "original url");
         System.out.println(status);
-        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"severity\":\"ERROR\"}", status.toString());
+        Assert.assertEquals("{\"statusCode\":400,\"code\":\"ERR11000\",\"severity\":\"ERROR\"}", status.toStringConditionally(false, false, false));
     }
 
-    private void initStatusConfig(boolean showMessage, boolean showMetadata, boolean showDescription) {
+    private void initStatusConfig(boolean showMessage, boolean showDescription, boolean showMetadata) {
         Map<String, Object> statusConfig = Config.getInstance().getJsonMapConfig("status");
         statusConfig.put("showMessage", showMessage);
         statusConfig.put("showMetadata", showMetadata);


### PR DESCRIPTION
issue #894
- now in setExchangeStatus(), it will use status.toStringConditionally() as the response result.
  Status.toString() for logging
- expose showMetadata, showDescription, showMessage to public
- adjust the tests