### PR TITLE
fixes #965

### DIFF
--- a/egress-router/README.md
+++ b/egress-router/README.md
@@ -1,0 +1,20 @@
+## egress-router module
+
+The module provides router (egress traffic) related handlers and util classes.
+
+ 
+
+When the system need call light-api from legacy system or API developed different technologies, for example, node.js, .net, the client side need process service discovery, JWT token management, load TLS certs...;
+
+Those client module feature can be done by using router handlers. The router handlers can delegate the client module features and help client side application to process service discovery, JWT token management, load TLS certs, etc.
+
+  
+
+
+### To learn how to use light-router, pleases refer to
+
+* [Light-router](https://github.com/networknt/light-router) github repo
+
+* [Getting Started](https://www.networknt.com/getting-started/light-router/) to learn core concepts
+* [Tutorial](https://www.networknt.com/tutorial/router/) with step by step guide for RESTful proxy
+* [Configuration](https://www.networknt.com/service/router/configuration/) for different configurations based on your situations

--- a/egress-router/pom.xml
+++ b/egress-router/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>light-4j</artifactId>
+        <groupId>com.networknt</groupId>
+        <version>2.0.28-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>egress-router</artifactId>
+    <packaging>jar</packaging>
+    <description>A module that contains all router related handler and util classes.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>cluster</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>http-string</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>handler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/egress-router/src/main/java/com/networknt/router/HostWhitelist.java
+++ b/egress-router/src/main/java/com/networknt/router/HostWhitelist.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.router;
+
+import com.networknt.config.Config;
+import com.networknt.config.ConfigException;
+
+import java.net.URI;
+import java.util.Arrays;
+
+public class HostWhitelist {
+
+    private static final RouterConfig config = (RouterConfig) Config.getInstance()
+            .getJsonObjectConfig("router", RouterConfig.class);
+
+    public boolean isHostAllowed(URI serviceUri) {
+        if (serviceUri != null) {
+            String[] hostWhitelist = config.getHostWhitelist();
+            if (hostWhitelist == null || hostWhitelist.length == 0) {
+                throw new ConfigException("No whitelist defined to allow the route to " + serviceUri);
+            }
+            String host = serviceUri.getHost();
+            return Arrays.stream(config.getHostWhitelist()).anyMatch(
+                    hostRegEx -> host != null && host.matches(hostRegEx));
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/egress-router/src/main/java/com/networknt/router/RouterConfig.java
+++ b/egress-router/src/main/java/com/networknt/router/RouterConfig.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.router;
+
+/**
+ * Config class for reverse router.
+ *
+ * @author Steve Hu
+ */
+public class RouterConfig {
+    boolean http2Enabled;
+    boolean httpsEnabled;
+    int maxRequestTime;
+    boolean rewriteHostHeader;
+    boolean reuseXForwarded;
+    int maxConnectionRetries;
+    String[] hostWhitelist;
+
+    public RouterConfig() {
+    }
+
+    public boolean isHttp2Enabled() {
+        return http2Enabled;
+    }
+
+    public void setHttp2Enabled(boolean http2Enabled) {
+        this.http2Enabled = http2Enabled;
+    }
+
+    public boolean isHttpsEnabled() {
+        return httpsEnabled;
+    }
+
+    public void setHttpsEnabled(boolean httpsEnabled) {
+        this.httpsEnabled = httpsEnabled;
+    }
+
+    public int getMaxRequestTime() {
+        return maxRequestTime;
+    }
+
+    public void setMaxRequestTime(int maxRequestTime) {
+        this.maxRequestTime = maxRequestTime;
+    }
+
+    public boolean isRewriteHostHeader() { return rewriteHostHeader; }
+
+    public void setRewriteHostHeader(boolean rewriteHostHeader) { this.rewriteHostHeader = rewriteHostHeader; }
+
+    public boolean isReuseXForwarded() { return reuseXForwarded; }
+
+    public void setReuseXForwarded(boolean reuseXForwarded) { this.reuseXForwarded = reuseXForwarded; }
+
+    public int getMaxConnectionRetries() { return maxConnectionRetries; }
+
+    public void setMaxConnectionRetries(int maxConnectionRetries) { this.maxConnectionRetries = maxConnectionRetries; }
+
+    public String[] getHostWhitelist() {
+        return hostWhitelist;
+    }
+
+    public void setHostWhitelist(String[] hostWhitelist) {
+        this.hostWhitelist = hostWhitelist;
+    }
+}

--- a/egress-router/src/main/java/com/networknt/router/RouterHandler.java
+++ b/egress-router/src/main/java/com/networknt/router/RouterHandler.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.router;
+
+import com.networknt.client.Http2Client;
+import com.networknt.config.Config;
+import io.undertow.UndertowOptions;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.ResponseCodeHandler;
+import io.undertow.server.handlers.proxy.LoadBalancingRouterProxyClient;
+import io.undertow.server.handlers.proxy.ProxyHandler;
+import org.xnio.OptionMap;
+
+/**
+ * This is a wrapper class for ProxyHandler as it is implemented as final. This class implements
+ * the HttpHandler which can be injected into the handler.yml configuration file as another option
+ * for the handlers injection. The other option is to use RouterHandlerProvider in service.yml file.
+ *
+ * @author Steve Hu
+ */
+public class RouterHandler implements HttpHandler {
+    static final String CONFIG_NAME = "router";
+    static RouterConfig config = (RouterConfig)Config.getInstance().getJsonObjectConfig(CONFIG_NAME, RouterConfig.class);
+
+    ProxyHandler proxyHandler;
+
+    public RouterHandler() {
+        // As we are building a client side router for the light platform, the assumption is the server will
+        // be on HTTP 2.0 TSL always. No need to handle HTTP 1.1 case here.
+        LoadBalancingRouterProxyClient client = new LoadBalancingRouterProxyClient();
+        if(config.httpsEnabled) client.setSsl(Http2Client.getInstance().getDefaultXnioSsl());
+        if(config.http2Enabled) {
+            client.setOptionMap(OptionMap.create(UndertowOptions.ENABLE_HTTP2, true));
+        } else {
+            client.setOptionMap(OptionMap.EMPTY);
+        }
+        proxyHandler = ProxyHandler.builder()
+                .setProxyClient(client)
+                .setMaxConnectionRetries(config.maxConnectionRetries)
+                .setMaxRequestTime(config.maxRequestTime)
+                .setReuseXForwarded(config.reuseXForwarded)
+                .setRewriteHostHeader(config.rewriteHostHeader)
+                .setNext(ResponseCodeHandler.HANDLE_404)
+                .build();
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange httpServerExchange) throws Exception {
+        proxyHandler.handleRequest(httpServerExchange);
+    }
+}

--- a/egress-router/src/main/java/com/networknt/router/middleware/HandlerUtils.java
+++ b/egress-router/src/main/java/com/networknt/router/middleware/HandlerUtils.java
@@ -1,0 +1,41 @@
+package com.networknt.router.middleware;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class HandlerUtils {
+	private static final Logger logger = LoggerFactory.getLogger(HandlerUtils.class);
+	
+    /**
+     * Looks up the appropriate serviceId for a given requestPath taken directly from exchange.
+     * Returns null if the path does not map to a configured service.
+     * @param searchKey search key
+     * @param mapping a map of prefix and service id
+     * @return serviceId that is found
+     */
+    public static String findServiceId(String searchKey, Map<String, String> mapping) {
+        if(logger.isDebugEnabled()) logger.debug("findServiceId for " + searchKey);
+        String serviceId = null;
+
+        for (Map.Entry<String, String> entry : mapping.entrySet()) {
+            String prefix = entry.getKey();
+            if(searchKey.startsWith(prefix)) {
+                if((searchKey.length() == prefix.length() || searchKey.charAt(prefix.length()) == '/')) {
+                    serviceId = entry.getValue();
+                    break;
+                }
+            }
+        }
+        if(logger.isDebugEnabled()) logger.debug("serviceId = " + serviceId);
+        return serviceId;
+    }
+
+    public static String normalisePath(String requestPath) {
+        if(!requestPath.startsWith("/")) {
+            return "/" + requestPath;
+        }
+        return requestPath;
+    }
+}

--- a/egress-router/src/main/java/com/networknt/router/middleware/SAMLTokenHandler.java
+++ b/egress-router/src/main/java/com/networknt/router/middleware/SAMLTokenHandler.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.router.middleware;
+
+import com.networknt.client.oauth.OauthHelper;
+import com.networknt.client.oauth.SAMLBearerRequest;
+import com.networknt.client.oauth.TokenResponse;
+import com.networknt.config.Config;
+import com.networknt.handler.Handler;
+import com.networknt.handler.MiddlewareHandler;
+import com.networknt.monad.Failure;
+import com.networknt.monad.Result;
+import com.networknt.monad.Success;
+import com.networknt.utility.ModuleRegistry;
+import io.undertow.Handlers;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * This is a middleware handler that is responsible for getting a JWT access token from
+ * OAuth 2.0 provider for the particular router client. In this use case it is assumed the client
+ * has a signed saml and a signed JWT token in the incoming HTTP headers. These two tokens will be
+ * passed to the authorization server to get the JWT access token.
+ * This handler will also be responsible for checking if the cached token is about to expired
+ * or not. In which case, it will renew the token in another thread. When request comes and
+ * the cached token is already expired, then it will block the request and go to the OAuth
+ * provider to get a new token and then resume the request to the next handler in the chain.
+ *
+ * This handler is very similar to the TokenHandler except it doesn't use the client credential
+ * grant type.
+ *
+ */
+public class SAMLTokenHandler implements MiddlewareHandler {
+    public static final String CONFIG_NAME = "token";
+    public static final String CLIENT_CONFIG_NAME = "client";
+    public static final String ENABLED = "enabled";
+    public static final String CONFIG_SECURITY = "security";
+
+
+    public static Map<String, Object> config = Config.getInstance().getJsonMapConfigNoCache(CONFIG_NAME);
+    static Logger logger = LoggerFactory.getLogger(SAMLTokenHandler.class);
+    private volatile HttpHandler next;
+
+    static final String OAUTH = "oauth";
+    static final String TOKEN = "token";
+    static final String OAUTH_HTTP2_SUPPORT = "oauthHttp2Support";
+
+    static final String SAMLAssertionHeader = "assertion";
+    static final String JWTAssertionHeader = "client_assertion";
+
+    static final String STATUS_SAMLBEARER_CREDENTIALS_TOKEN_NOT_AVAILABLE = "ERR10009";
+
+    static Map<String, Object> clientConfig;
+    static Map<String, Object> tokenConfig;
+    static boolean oauthHttp2Support;
+
+    private final Object lock = new Object();
+
+    public SAMLTokenHandler() {
+        clientConfig = Config.getInstance().getJsonMapConfig(CLIENT_CONFIG_NAME);
+        if(clientConfig != null) {
+            Map<String, Object> oauthConfig = (Map<String, Object>)clientConfig.get(OAUTH);
+            if(oauthConfig != null) {
+                tokenConfig = (Map<String, Object>)oauthConfig.get(TOKEN);
+            }
+        }
+        Map<String, Object> securityConfig = Config.getInstance().getJsonMapConfig(CONFIG_SECURITY);
+        if(securityConfig != null) {
+            Boolean b = (Boolean)securityConfig.get(OAUTH_HTTP2_SUPPORT);
+            oauthHttp2Support = (b == null ? false : b.booleanValue());
+        }
+    }
+
+    @Override
+    public void handleRequest(final HttpServerExchange exchange) throws Exception {
+        // check if there is a bear token in the authorization header in the request. If this
+        // is one, then this must be the subject token that is linked to the original user.
+        // We will keep this token in the Authorization header but create a new token with
+        // client credentials grant type with scopes for the particular client. (Can we just
+        // assume that the subject token has the scope already?)
+        logger.debug(exchange.toString());
+        Result<String> result = getSAMLBearerToken(exchange.getRequestHeaders().getFirst(SAMLAssertionHeader), exchange.getRequestHeaders().getFirst(JWTAssertionHeader));
+        if(result.isFailure()) {
+            OauthHelper.sendStatusToResponse(exchange, result.getError());
+            return;
+        }
+        exchange.getRequestHeaders().put(Headers.AUTHORIZATION, "Bearer " + result.getResult());
+        exchange.getRequestHeaders().remove(SAMLAssertionHeader);
+        exchange.getRequestHeaders().remove(JWTAssertionHeader);
+        Handler.next(exchange, next);
+    }
+
+    @Override
+    public HttpHandler getNext() {
+        return next;
+    }
+
+    @Override
+    public MiddlewareHandler setNext(final HttpHandler next) {
+        Handlers.handlerNotNull(next);
+        this.next = next;
+        return this;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        Object object = config.get(ENABLED);
+        return object != null && (Boolean) object;
+    }
+
+    @Override
+    public void register() {
+        ModuleRegistry.registerModule(SAMLTokenHandler.class.getName(), config, null);
+    }
+
+
+    private Result<String> getSAMLBearerToken(String samlAssertion , String jwtAssertion) {
+        SAMLBearerRequest tokenRequest = new SAMLBearerRequest(samlAssertion , jwtAssertion);
+        Result<TokenResponse> tokenResponse = OauthHelper.getTokenFromSamlResult(tokenRequest);
+        if(tokenResponse.isSuccess()) {
+            String jwt = tokenResponse.getResult().getAccessToken();
+            logger.debug("SAMLBearer Grant Type jwt: ", jwt);
+            return Success.of(jwt);
+        } else {
+            return Failure.of(tokenResponse.getError());
+        }
+    }
+}

--- a/egress-router/src/main/java/com/networknt/router/middleware/ServiceDictHandler.java
+++ b/egress-router/src/main/java/com/networknt/router/middleware/ServiceDictHandler.java
@@ -1,0 +1,117 @@
+package com.networknt.router.middleware;
+
+import com.networknt.config.Config;
+import com.networknt.handler.Handler;
+import com.networknt.handler.MiddlewareHandler;
+import com.networknt.httpstring.HttpStringConstants;
+import com.networknt.utility.ModuleRegistry;
+import com.networknt.utility.StringUtils;
+import io.undertow.Handlers;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderValues;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Find service Ids using a combination of path prefix and request method.
+ * 
+ * @author Daniel Zhao
+ *
+ */
+
+@SuppressWarnings("unchecked")
+public class ServiceDictHandler implements MiddlewareHandler {
+	private static final Logger logger = LoggerFactory.getLogger(ServiceDictHandler.class);
+	protected static final String INTERNAL_KEY_FORMAT = "%s %s";
+	
+    public static final String CONFIG_NAME = "serviceDict";
+    public static final String ENABLED = "enabled";
+    public static final String MAPPING = "mapping";
+    public static final String DELIMITOR = "@";
+
+    public static Map<String, Object> config = Config.getInstance().getJsonMapConfigNoCache(CONFIG_NAME);
+	protected static Map<String, String> rawMappings = (Map<String, String>)config.get(MAPPING);
+	public static Map<String, String> mappings;
+	
+	static {
+		mappings = new HashMap<>();
+		
+		for (Map.Entry<String, String> entry : rawMappings.entrySet()) {
+			mappings.put(toInternalKey(entry.getKey()), entry.getValue());
+		}
+		
+		mappings = Collections.unmodifiableMap(mappings);
+	}
+	
+    
+    private volatile HttpHandler next;
+
+    static final String STATUS_INVALID_REQUEST_PATH = "ERR10007";
+
+    public ServiceDictHandler() {
+        logger.info("ServiceDictHandler is constructed");
+    }
+
+	@Override
+	public void handleRequest(HttpServerExchange exchange) throws Exception {
+        HeaderValues serviceIdHeader = exchange.getRequestHeaders().get(HttpStringConstants.SERVICE_ID);
+        String serviceId = serviceIdHeader != null ? serviceIdHeader.peekFirst() : null;
+        if(serviceId == null) {
+            String requestPath = exchange.getRequestURI();
+            String httpMethod = exchange.getRequestMethod().toString().toLowerCase();
+            
+            serviceId = HandlerUtils.findServiceId(toInternalKey(httpMethod, requestPath), mappings);
+            if(serviceId == null) {
+                setExchangeStatus(exchange, STATUS_INVALID_REQUEST_PATH, requestPath);
+                return;
+            }
+            exchange.getRequestHeaders().put(HttpStringConstants.SERVICE_ID, serviceId);
+        }
+        Handler.next(exchange, next);
+	}
+
+    private static String toInternalKey(String key) {
+    	String[] tokens = StringUtils.trimToEmpty(key).split(DELIMITOR);
+    	
+    	if (tokens.length ==2) {
+    		return toInternalKey(tokens[1], tokens[0]);
+    	}
+    	
+    	logger.warn("Invalid key {}", key);
+    	return key;
+    }
+    
+    protected static String toInternalKey(String method, String path) {
+    	return String.format(INTERNAL_KEY_FORMAT, method, HandlerUtils.normalisePath(path));
+    }
+
+	@Override
+    public HttpHandler getNext() {
+        return next;
+    }
+
+    @Override
+    public MiddlewareHandler setNext(final HttpHandler next) {
+        Handlers.handlerNotNull(next);
+        this.next = next;
+        return this;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        Object object = config.get(ENABLED);
+        return object != null && (Boolean)object;
+    }
+
+    @Override
+    public void register() {
+        ModuleRegistry.registerModule(ServiceDictHandler.class.getName(), config, null);
+    }
+
+
+}

--- a/egress-router/src/main/java/com/networknt/router/middleware/TokenHandler.java
+++ b/egress-router/src/main/java/com/networknt/router/middleware/TokenHandler.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.router.middleware;
+
+import com.networknt.client.oauth.Jwt;
+import com.networknt.client.oauth.OauthHelper;
+import com.networknt.config.Config;
+import com.networknt.handler.Handler;
+import com.networknt.handler.MiddlewareHandler;
+import com.networknt.monad.Result;
+import com.networknt.utility.ModuleRegistry;
+import io.undertow.Handlers;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * This is a middleware handler that is responsible for getting a JWT access token from
+ * OAuth 2.0 provider for the particular router client. The only token that is supported in
+ * this handler is client credentials token as there is no user information available here.
+ *
+ * The client_id will be retrieved from client.yml and client_secret will be retrieved from
+ * secret.yml
+ *
+ * This handler will also responsible for checking if the cached token is about to expired
+ * or not. In which case, it will renew the token in another thread. When request comes and
+ * the cached token is already expired, then it will block the request and go to the OAuth
+ * provider to get a new token and then resume the request to the next handler in the chain.
+ *
+ * The logic is very similar with client module in light-4j but this is implemented in a
+ * handler instead.
+ *
+ * This light-router is designed for standalone or client that is not implemented in Java
+ * Otherwise, you should use client module instead of this one. In the future, we might
+ * add Authorization Code grant type support by providing an endpoint in the light-router
+ * to accept Authorization Code redirect and then get the token from OAuth 2.0 provider.
+ *
+ * There is no specific configuration file for this handler just to enable or disable it. If
+ * you want to bypass this handler, you can comment it out from service.yml middleware
+ * handler section or change the token.yml to disable it.
+ *
+ * Once the token is retrieved from OAuth 2.0 provider, it will be placed in the header as
+ * Authorization Bearer token according to the OAuth 2.0 specification.
+ *
+ */
+public class TokenHandler implements MiddlewareHandler {
+    public static final String CONFIG_NAME = "token";
+    public static final String ENABLED = "enabled";
+
+    public static Map<String, Object> config = Config.getInstance().getJsonMapConfigNoCache(CONFIG_NAME);
+    static Logger logger = LoggerFactory.getLogger(TokenHandler.class);
+    private volatile HttpHandler next;
+    // Cached jwt token for this handler on behalf of a client.
+    private final Jwt cachedJwt = new Jwt();
+    public TokenHandler() { }
+
+    @Override
+    public void handleRequest(final HttpServerExchange exchange) throws Exception {
+        // check if there is a bear token in the authorization header in the request. If this
+        // is one, then this must be the subject token that is linked to the original user.
+        // We will keep this token in the Authorization header but create a new token with
+        // client credentials grant type with scopes for the particular client. (Can we just
+        // assume that the subject token has the scope already?)
+        Result result = OauthHelper.populateCCToken(cachedJwt);
+        if(result.isFailure()) {
+            logger.error("cannot populate or renew jwt for client credential grant type");
+            OauthHelper.sendStatusToResponse(exchange, result.getError());
+            return;
+        }
+        exchange.getRequestHeaders().put(Headers.AUTHORIZATION, "Bearer " + cachedJwt.getJwt());
+        Handler.next(exchange, next);
+    }
+
+    @Override
+    public HttpHandler getNext() {
+        return next;
+    }
+
+    @Override
+    public MiddlewareHandler setNext(final HttpHandler next) {
+        Handlers.handlerNotNull(next);
+        this.next = next;
+        return this;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        Object object = config.get(ENABLED);
+        return object != null && (Boolean) object;
+    }
+
+    @Override
+    public void register() {
+        ModuleRegistry.registerModule(TokenHandler.class.getName(), config, null);
+    }
+}

--- a/egress-router/src/main/java/io/undertow/server/handlers/proxy/LoadBalancingRouterProxyClient.java
+++ b/egress-router/src/main/java/io/undertow/server/handlers/proxy/LoadBalancingRouterProxyClient.java
@@ -1,0 +1,366 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server.handlers.proxy;
+
+import com.networknt.client.ClientConfig;
+import com.networknt.client.ServerExchangeCarrier;
+import com.networknt.cluster.Cluster;
+import com.networknt.config.ConfigException;
+import com.networknt.httpstring.AttachmentConstants;
+import com.networknt.httpstring.HttpStringConstants;
+import com.networknt.router.HostWhitelist;
+import com.networknt.service.SingletonServiceFactory;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.tag.Tags;
+import io.undertow.client.UndertowClient;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.AttachmentKey;
+import io.undertow.util.AttachmentList;
+import io.undertow.util.CopyOnWriteMap;
+import io.undertow.util.HeaderMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xnio.OptionMap;
+import org.xnio.ssl.XnioSsl;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.undertow.server.handlers.proxy.ProxyConnectionPool.AvailabilityType.*;
+
+/**
+ * This is a proxy client that supports multiple downstream services.
+ *
+ * @author Steve Hu
+ */
+public class LoadBalancingRouterProxyClient implements ProxyClient {
+    private static Logger logger = LoggerFactory.getLogger(LoadBalancingRouterProxyClient.class);
+    private static final AttachmentKey<AttachmentList<Host>> ATTEMPTED_HOSTS = AttachmentKey.createList(Host.class);
+    private static Cluster cluster = SingletonServiceFactory.getBean(Cluster.class);
+    private static final HostWhitelist HOST_WHITELIST = new HostWhitelist();
+
+    /**
+     * Time in seconds between retries for problem servers
+     */
+    private volatile int problemServerRetry = 10;
+
+    /**
+     * The number of connections to create per thread
+     */
+    private volatile int connectionsPerThread = 10;
+    private volatile int maxQueueSize = 0;
+    private volatile int softMaxConnectionsPerThread = 5;
+    private volatile int ttl = -1;
+
+    /**
+     * The service hosts list map
+     */
+    private volatile Map<String, Host[]> hosts = new CopyOnWriteMap<>();
+
+    private final HostSelector hostSelector;
+    private final UndertowClient client;
+
+    /**
+     * These needs to be come from configuration
+     */
+    private XnioSsl ssl;
+    private OptionMap options;
+    private InetSocketAddress bindAddress;
+
+    private static final ProxyTarget PROXY_TARGET = new ProxyTarget() {
+    };
+
+    public LoadBalancingRouterProxyClient() {
+        this(UndertowClient.getInstance());
+    }
+
+    public LoadBalancingRouterProxyClient(UndertowClient client) {
+        this(client, null);
+    }
+
+    public LoadBalancingRouterProxyClient(UndertowClient client, HostSelector hostSelector) {
+        this.client = client;
+        if (hostSelector == null) {
+            this.hostSelector = new RoundRobinHostSelector();
+        } else {
+            this.hostSelector = hostSelector;
+        }
+    }
+
+    public LoadBalancingRouterProxyClient setSsl(final XnioSsl ssl) {
+        this.ssl = ssl;
+        return this;
+    }
+
+    public LoadBalancingRouterProxyClient setOptionMap(final OptionMap options) {
+        this.options = options;
+        return this;
+    }
+
+    public LoadBalancingRouterProxyClient setProblemServerRetry(int problemServerRetry) {
+        this.problemServerRetry = problemServerRetry;
+        return this;
+    }
+
+    public int getProblemServerRetry() {
+        return problemServerRetry;
+    }
+
+    public int getConnectionsPerThread() {
+        return connectionsPerThread;
+    }
+
+    public LoadBalancingRouterProxyClient setConnectionsPerThread(int connectionsPerThread) {
+        this.connectionsPerThread = connectionsPerThread;
+        return this;
+    }
+
+    public int getMaxQueueSize() {
+        return maxQueueSize;
+    }
+
+    public LoadBalancingRouterProxyClient setMaxQueueSize(int maxQueueSize) {
+        this.maxQueueSize = maxQueueSize;
+        return this;
+    }
+
+    public LoadBalancingRouterProxyClient setTtl(int ttl) {
+        this.ttl = ttl;
+        return this;
+    }
+
+    public LoadBalancingRouterProxyClient setSoftMaxConnectionsPerThread(int softMaxConnectionsPerThread) {
+        this.softMaxConnectionsPerThread = softMaxConnectionsPerThread;
+        return this;
+    }
+
+    public synchronized void addHosts(final String serviceId, final String envTag) {
+        String key = envTag == null ? serviceId : serviceId + "|" + envTag;
+        List<URI> uris = cluster.services(ssl == null ? "http" : "https", serviceId, envTag);
+        hosts.remove(key);
+        Host[] newHosts = new Host[uris.size()];
+        for (int i = 0; i < uris.size(); i++) {
+            Host h = new Host(serviceId, bindAddress, uris.get(i), ssl, options);
+            newHosts[i] = h;
+        }
+        hosts.put(key, newHosts);
+    }
+
+    @Override
+    public ProxyTarget findTarget(HttpServerExchange exchange) {
+        return PROXY_TARGET;
+    }
+
+    @Override
+    public void getConnection(ProxyTarget target, HttpServerExchange exchange, final ProxyCallback<ProxyConnection> callback, long timeout, TimeUnit timeUnit) {
+        try {
+            Host host = selectHost(exchange);
+            if (host == null) {
+                // give it second chance for service discovery again when problem occurs.
+                host = selectHost(exchange);
+            }
+            if (host == null) {
+                callback.couldNotResolveBackend(exchange);
+            } else {
+                exchange.addToAttachmentList(ATTEMPTED_HOSTS, host);
+                host.connectionPool.connect(target, exchange, callback, timeout, timeUnit, false);
+            }
+        } catch (Exception ex) {
+            logger.error("Failed to get connection", ex);
+            exchange.setReasonPhrase(ex.getMessage());
+            callback.failed(exchange);
+        }
+    }
+
+    protected Host selectHost(HttpServerExchange exchange) {
+        // get serviceId, env tag and hash key from header.
+        HeaderMap headers = exchange.getRequestHeaders();
+        String serviceId = headers.getFirst(HttpStringConstants.SERVICE_ID);
+        String serviceUrl = headers.getFirst(HttpStringConstants.SERVICE_URL);
+        // remove the header here in case the downstream service is another light-router instance.
+        if(serviceUrl != null) headers.remove(HttpStringConstants.SERVICE_URL);
+        String envTag = headers.getFirst(HttpStringConstants.ENV_TAG);
+        String key = envTag == null ?  (serviceUrl != null ? serviceUrl : serviceId) :  (serviceUrl != null ? serviceUrl : serviceId) + "|" + envTag;
+        AttachmentList<Host> attempted = exchange.getAttachment(ATTEMPTED_HOSTS);
+        Host[] hostArray = this.hosts.get(key);
+        if (hostArray == null || hostArray.length == 0) {
+            // this must be the first this service is called since the router is started. discover here.
+            if (serviceUrl != null) {
+                try {
+                    URI uri = new URI(serviceUrl);
+                    if (HOST_WHITELIST != null) {
+                        if (HOST_WHITELIST.isHostAllowed(uri)) {
+                            this.hosts.put(key, new Host[] {new Host(serviceId, bindAddress, uri, ssl, options) });
+                        } else {
+                            throw new RuntimeException(String.format("Route to %s is not allowed in the host whitelist", serviceUrl));
+                        }
+
+                    } else {
+                        throw new ConfigException(
+                                String.format("Host Whitelist must be enabled to support route based on %s in Http header",
+                                        HttpStringConstants.SERVICE_URL));
+                    }
+                } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                addHosts(serviceId, envTag);
+            }
+            hostArray = this.hosts.get(key);
+        }
+
+        int host = hostSelector.selectHost(hostArray);
+
+        final int startHost = host; //if the all hosts have problems we come back to this one
+        Host full = null;
+        Host problem = null;
+        do {
+            Host selected = hostArray[host];
+            if (attempted == null || !attempted.contains(selected)) {
+                ProxyConnectionPool.AvailabilityType available = selected.connectionPool.available();
+                if (available == AVAILABLE) {
+                    // inject the jaeger tracer.
+                    injectTracer(exchange, selected);
+                    return selected;
+                } else if (available == FULL && full == null) {
+                    full = selected;
+                } else if ((available == PROBLEM || available == FULL_QUEUE) && problem == null) {
+                    problem = selected;
+                }
+            }
+            host = (host + 1) % hostArray.length;
+        } while (host != startHost);
+        if (full != null) {
+            // inject the jaeger tracer.
+            injectTracer(exchange, full);
+            return full;
+        }
+        if (problem != null) {
+            addHosts(serviceId, envTag);
+        }
+        //no available hosts
+        return null;
+    }
+
+    private void injectTracer(HttpServerExchange exchange, Host host) {
+        if(ClientConfig.get().isInjectOpenTracing()) {
+            Tracer tracer = exchange.getAttachment(AttachmentConstants.EXCHANGE_TRACER);
+            Span rootSpan = exchange.getAttachment(AttachmentConstants.ROOT_SPAN);
+            if(tracer != null) {
+                tracer.activateSpan(rootSpan);
+                Tags.SPAN_KIND.set(tracer.activeSpan(), Tags.SPAN_KIND_CLIENT);
+                Tags.HTTP_METHOD.set(tracer.activeSpan(), exchange.getRequestMethod().toString());
+                Tags.HTTP_URL.set(tracer.activeSpan(), exchange.getRequestURI());
+                Tags.PEER_PORT.set(tracer.activeSpan(), host.uri.getPort());
+                Tags.PEER_HOSTNAME.set(tracer.activeSpan(), host.uri.getHost());
+                tracer.inject(tracer.activeSpan().context(), Format.Builtin.HTTP_HEADERS, new ServerExchangeCarrier(exchange));
+            }
+        }
+    }
+
+    /**
+     * Should only be used for tests
+     * <p>
+     * DO NOT CALL THIS METHOD WHEN REQUESTS ARE IN PROGRESS
+     * <p>
+     * It is not thread safe so internal state can get messed up.
+     */
+    public void closeCurrentConnections() {
+        for (Map.Entry<String, Host[]> entry : hosts.entrySet()) {
+            for (Host host : entry.getValue()) {
+                host.closeCurrentConnections();
+            }
+        }
+    }
+
+    public final class Host extends ConnectionPoolErrorHandler.SimpleConnectionPoolErrorHandler implements ConnectionPoolManager {
+        final ProxyConnectionPool connectionPool;
+        final String serviceId;
+        final URI uri;
+        final XnioSsl ssl;
+
+        private Host(String serviceId, InetSocketAddress bindAddress, URI uri, XnioSsl ssl, OptionMap options) {
+            this.connectionPool = new ProxyConnectionPool(this, bindAddress, uri, ssl, client, options);
+            this.serviceId = serviceId;
+            this.uri = uri;
+            this.ssl = ssl;
+        }
+
+        @Override
+        public int getProblemServerRetry() {
+            return problemServerRetry;
+        }
+
+        @Override
+        public int getMaxConnections() {
+            return connectionsPerThread;
+        }
+
+        @Override
+        public int getMaxCachedConnections() {
+            return connectionsPerThread;
+        }
+
+        @Override
+        public int getSMaxConnections() {
+            return softMaxConnectionsPerThread;
+        }
+
+        @Override
+        public long getTtl() {
+            return ttl;
+        }
+
+        @Override
+        public int getMaxQueueSize() {
+            return maxQueueSize;
+        }
+
+        public URI getUri() {
+            return uri;
+        }
+
+        void closeCurrentConnections() {
+            connectionPool.closeCurrentConnections();
+        }
+    }
+
+    public interface HostSelector {
+
+        int selectHost(Host[] availableHosts);
+    }
+
+    static class RoundRobinHostSelector implements HostSelector {
+
+        private final AtomicInteger currentHost = new AtomicInteger(0);
+
+        @Override
+        public int selectHost(Host[] availableHosts) {
+            return currentHost.incrementAndGet() % availableHosts.length;
+        }
+    }
+
+}

--- a/egress-router/src/main/resources/config/router.yml
+++ b/egress-router/src/main/resources/config/router.yml
@@ -1,0 +1,22 @@
+---
+# Light Router Configuration
+# As this router is built to support discovery and security for light-4j services,
+# the outbound connection is always HTTP 2.0 with TLS enabled.
+
+# If HTTP 2.0 protocol will be accepted from incoming request.
+http2Enabled: true
+
+# If TLS is enabled when accepting incoming request. Should be true on test and prod.
+httpsEnabled: true
+
+# Max request time in milliseconds before timeout to the server.
+maxRequestTime: 1000
+
+# Rewrite Host Header with the target host and port and write X_FORWARDED_HOST with original host
+rewriteHostHeader: true
+
+# Reuse XForwarded for the target XForwarded header
+reuseXForwarded: false
+
+# Max Connection Retries
+maxConnectionRetries: 3

--- a/egress-router/src/test/java/com/networknt/router/HostWhitelistTest.java
+++ b/egress-router/src/test/java/com/networknt/router/HostWhitelistTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.router;
+
+import com.networknt.config.Config;
+import com.networknt.service.SingletonServiceFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class HostWhitelistTest {
+
+    private HostWhitelist hostWhitelist;
+
+    @BeforeClass
+    public static void setUp() {
+        RouterConfig config = (RouterConfig) Config.getInstance()
+                .getJsonObjectConfig("router", RouterConfig.class);
+        config.setHostWhitelist(new String[] {
+                "192.168.0.*",
+                "10.1.2.*"
+        });
+        SingletonServiceFactory.setBean("com.networknt.router.HostWhitelist", new HostWhitelist());
+    }
+
+    @Before
+    public void init() {
+        hostWhitelist = SingletonServiceFactory.getBean(HostWhitelist.class);
+    }
+
+    @Test
+    public void testHostAllowed() throws URISyntaxException {
+        Assert.assertTrue(hostWhitelist.isHostAllowed(new URI("http://192.168.0.1")));
+        Assert.assertTrue(hostWhitelist.isHostAllowed(new URI("http://10.1.2.3:8543")));
+        Assert.assertTrue(hostWhitelist.isHostAllowed(new URI("https://192.168.0.10:8765")));
+    }
+
+    @Test
+    public void testHostNotAllowed() throws URISyntaxException {
+        Assert.assertFalse(hostWhitelist.isHostAllowed(new URI("http://192.168.2.1")));
+        Assert.assertFalse(hostWhitelist.isHostAllowed(new URI("http2://10.2.3.4:8643")));
+        Assert.assertFalse(hostWhitelist.isHostAllowed(new URI("https://192.168.1.20:7654")));
+    }
+
+}

--- a/egress-router/src/test/resources/config/router.yml
+++ b/egress-router/src/test/resources/config/router.yml
@@ -1,0 +1,26 @@
+---
+# Light Router Configuration
+# As this router is built to support discovery and security for light-4j services,
+# the outbound connection is always HTTP 2.0 with TLS enabled.
+
+# If HTTP 2.0 protocol will be accepted from incoming request.
+http2Enabled: false
+
+# If TLS is enabled when accepting incoming request. Should be true on test and prod.
+httpsEnabled: true
+
+# Max request time in milliseconds before timeout to the server.
+maxRequestTime: 1000
+
+# Rewrite Host Header with the target host and port and write X_FORWARDED_HOST with original host
+rewriteHostHeader: true
+
+# Reuse XForwarded for the target XForwarded header
+reuseXForwarded: false
+
+# Max Connection Retries
+maxConnectionRetries: 3
+
+# allowed host list. Use Regex to do wildcard match
+hostWhitelist:
+  - 192.168.0.*

--- a/egress-router/src/test/resources/config/service.yml
+++ b/egress-router/src/test/resources/config/service.yml
@@ -1,0 +1,16 @@
+# Singleton service factory configuration/IoC injection
+singletons:
+- com.networknt.registry.URL:
+  - com.networknt.registry.URLImpl:
+      protocol: https
+      host: localhost
+      port: 8080
+      path: direct
+      parameters:
+        com.networknt.test-1.0.0: http://localhost:8082?environment=dev
+- com.networknt.registry.Registry:
+  - com.networknt.registry.support.DirectRegistry
+- com.networknt.balance.LoadBalance:
+  - com.networknt.balance.RoundRobinLoadBalance
+- com.networknt.cluster.Cluster:
+  - com.networknt.cluster.LightCluster

--- a/ingress-proxy/README.md
+++ b/ingress-proxy/README.md
@@ -1,0 +1,17 @@
+## ingress-proxy module
+
+The module provides proxy (ingress traffic) related handlers and util classes.
+
+The proxy handlers delegate light API server feature and provide server side cross-cutting concerns. For example, schema validation, JWT verification, etc.
+ 
+
+
+
+### To learn how to use this proxy, pleases refer to 
+
+* [light-proxy](https://github.com/networknt/light-proxy) github repo
+
+* [Getting Started](https://doc.networknt.com/getting-started/light-proxy/) to learn core concepts
+* [Tutorial](https://doc.networknt.com/tutorial/proxy/) with step by step guide for RESTful proxy
+* [Configuration](https://doc.networknt.com/service/proxy/configuration/) for different configurations based on your situations
+* [Artifact](https://doc.networknt.com/service/proxy/artifact/) to guide customer to choose the right artifact to deploy light-proxy.

--- a/ingress-proxy/pom.xml
+++ b/ingress-proxy/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>light-4j</artifactId>
+        <groupId>com.networknt</groupId>
+        <version>2.0.28-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>ingress-proxy</artifactId>
+    <packaging>jar</packaging>
+    <description>A module that contains all proxy related handler and util classes.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>cluster</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>http-string</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>handler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/ingress-proxy/src/main/java/com/networknt/proxy/LightProxyHandler.java
+++ b/ingress-proxy/src/main/java/com/networknt/proxy/LightProxyHandler.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.proxy;
+
+import com.networknt.client.Http2Client;
+import com.networknt.config.Config;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.ResponseCodeHandler;
+import io.undertow.server.handlers.proxy.LoadBalancingProxyClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+
+/**
+ * This is a wrapper class for LightProxyHandler as it is implemented as final. This class implements
+ * the HttpHandler which can be injected into the handler.yml configuration file as another option
+ * for the handlers injection. The other option is to use RouterHandlerProvider in service.yml file.
+ *
+ * @author Steve Hu
+ */
+public class LightProxyHandler implements HttpHandler {
+    static final String CONFIG_NAME = "proxy";
+    static final Logger logger = LoggerFactory.getLogger(LightProxyHandler.class);
+    static ProxyConfig config = (ProxyConfig) Config.getInstance().getJsonObjectConfig(CONFIG_NAME, ProxyConfig.class);
+
+    ProxyHandler proxyHandler;
+
+    public LightProxyHandler() {
+        List<String> hosts = Arrays.asList(config.getHosts().split(","));
+        if(config.httpsEnabled) {
+            LoadBalancingProxyClient loadBalancer = new LoadBalancingProxyClient()
+                    .setConnectionsPerThread(config.getConnectionsPerThread());
+            hosts.forEach(handlingConsumerWrapper(host -> loadBalancer.addHost(new URI(host), Http2Client.getInstance().getDefaultXnioSsl()), URISyntaxException.class));
+            proxyHandler = ProxyHandler.builder()
+                    .setProxyClient(loadBalancer)
+                    .setMaxConnectionRetries(config.maxConnectionRetries)
+                    .setMaxRequestTime(config.maxRequestTime)
+                    .setReuseXForwarded(config.reuseXForwarded)
+                    .setRewriteHostHeader(config.rewriteHostHeader)
+                    .setNext(ResponseCodeHandler.HANDLE_404)
+                    .build();
+        } else {
+            LoadBalancingProxyClient loadBalancer = new LoadBalancingProxyClient()
+                    .setConnectionsPerThread(config.getConnectionsPerThread());
+            hosts.forEach(handlingConsumerWrapper(host -> loadBalancer.addHost(new URI(host)), URISyntaxException.class));
+            proxyHandler = ProxyHandler.builder()
+                    .setProxyClient(loadBalancer)
+                    .setMaxConnectionRetries(config.maxConnectionRetries)
+                    .setMaxRequestTime(config.maxRequestTime)
+                    .setReuseXForwarded(config.reuseXForwarded)
+                    .setRewriteHostHeader(config.rewriteHostHeader)
+                    .setNext(ResponseCodeHandler.HANDLE_404)
+                    .build();
+        }
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange httpServerExchange) throws Exception {
+        proxyHandler.handleRequest(httpServerExchange);
+    }
+
+    @FunctionalInterface
+    public interface ThrowingConsumer<T, E extends Exception> {
+        void accept(T t) throws E;
+    }
+    static <T, E extends Exception> Consumer<T> handlingConsumerWrapper(
+            ThrowingConsumer<T, E> throwingConsumer, Class<E> exceptionClass) {
+
+        return i -> {
+            try {
+                throwingConsumer.accept(i);
+            } catch (Exception ex) {
+                try {
+                    E exCast = exceptionClass.cast(ex);
+                    logger.error("Exception occured :", ex);
+                } catch (ClassCastException ccEx) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        };
+    }
+
+}

--- a/ingress-proxy/src/main/java/com/networknt/proxy/ProxyConfig.java
+++ b/ingress-proxy/src/main/java/com/networknt/proxy/ProxyConfig.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2016 Network New Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.proxy;
+
+import java.util.List;
+
+/**
+ * Config class for reverse proxy.
+ *
+ * @author Steve Hu
+ */
+public class ProxyConfig {
+    boolean enabled;
+    boolean http2Enabled;
+    boolean httpsEnabled;
+    String hosts;
+    int connectionsPerThread;
+    int maxRequestTime;
+    boolean rewriteHostHeader;
+    boolean reuseXForwarded;
+    int maxConnectionRetries;
+
+    public ProxyConfig() {
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isHttp2Enabled() {
+        return http2Enabled;
+    }
+
+    public void setHttp2Enabled(boolean http2Enabled) {
+        this.http2Enabled = http2Enabled;
+    }
+
+    public boolean isHttpsEnabled() {
+        return httpsEnabled;
+    }
+
+    public void setHttpsEnabled(boolean httpsEnabled) {
+        this.httpsEnabled = httpsEnabled;
+    }
+
+    public String getHosts() {
+        return hosts;
+    }
+
+    public void setHosts(String hosts) {
+        this.hosts = hosts;
+    }
+
+    public int getConnectionsPerThread() {
+        return connectionsPerThread;
+    }
+
+    public void setConnectionsPerThread(int connectionsPerThread) {
+        this.connectionsPerThread = connectionsPerThread;
+    }
+
+    public int getMaxRequestTime() {
+        return maxRequestTime;
+    }
+
+    public void setMaxRequestTime(int maxRequestTime) {
+        this.maxRequestTime = maxRequestTime;
+    }
+
+    public boolean isRewriteHostHeader() { return rewriteHostHeader; }
+
+    public void setRewriteHostHeader(boolean rewriteHostHeader) { this.rewriteHostHeader = rewriteHostHeader; }
+
+    public boolean isReuseXForwarded() { return reuseXForwarded; }
+
+    public void setReuseXForwarded(boolean reuseXForwarded) { this.reuseXForwarded = reuseXForwarded; }
+
+    public int getMaxConnectionRetries() { return maxConnectionRetries; }
+
+    public void setMaxConnectionRetries(int maxConnectionRetries) { this.maxConnectionRetries = maxConnectionRetries; }
+}

--- a/ingress-proxy/src/main/java/com/networknt/proxy/ProxyHandler.java
+++ b/ingress-proxy/src/main/java/com/networknt/proxy/ProxyHandler.java
@@ -1,0 +1,866 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.networknt.proxy;
+
+import io.undertow.UndertowLogger;
+import io.undertow.UndertowMessages;
+import io.undertow.attribute.ExchangeAttribute;
+import io.undertow.client.*;
+import io.undertow.io.IoCallback;
+import io.undertow.io.Sender;
+import io.undertow.predicate.IdempotentPredicate;
+import io.undertow.predicate.Predicate;
+import io.undertow.server.*;
+import io.undertow.server.handlers.ResponseCodeHandler;
+import io.undertow.server.handlers.proxy.ProxyCallback;
+import io.undertow.server.handlers.proxy.ProxyClient;
+import io.undertow.server.handlers.proxy.ProxyConnection;
+import io.undertow.server.protocol.http.HttpAttachments;
+import io.undertow.server.protocol.http.HttpContinue;
+import io.undertow.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xnio.*;
+import org.xnio.channels.StreamSinkChannel;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.Channel;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * An HTTP handler which proxies content to a remote server.
+ * <p>
+ * This handler acts like a filter. The {@link ProxyClient} has a chance to decide if it
+ * knows how to proxy the request. If it does then it will provide a connection that can
+ * used to connect to the remote server, otherwise the next handler will be invoked and the
+ * request will proceed as normal.
+ *
+ * This handler uses non blocking IO
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public final class ProxyHandler implements HttpHandler {
+
+    private static final int DEFAULT_MAX_RETRY_ATTEMPTS = Integer.getInteger("maxRetries", 1);
+
+    private static final Logger log = LoggerFactory.getLogger(ProxyHandler.class);
+
+    public static final String UTF_8 = StandardCharsets.UTF_8.name();
+
+    private static final AttachmentKey<ProxyConnection> CONNECTION = AttachmentKey.create(ProxyConnection.class);
+    private static final AttachmentKey<HttpServerExchange> EXCHANGE = AttachmentKey.create(HttpServerExchange.class);
+    private static final AttachmentKey<XnioExecutor.Key> TIMEOUT_KEY = AttachmentKey.create(XnioExecutor.Key.class);
+
+    private final ProxyClient proxyClient;
+    private final int maxRequestTime;
+
+    /**
+     * Map of additional headers to add to the request.
+     */
+    private final Map<HttpString, ExchangeAttribute> requestHeaders = new CopyOnWriteMap<>();
+
+    private final HttpHandler next;
+
+    private volatile boolean rewriteHostHeader;
+    private volatile boolean reuseXForwarded;
+    private volatile int maxConnectionRetries;
+
+    private final Predicate idempotentRequestPredicate;
+
+    @Deprecated
+    public ProxyHandler(ProxyClient proxyClient, int maxRequestTime, HttpHandler next) {
+        this(proxyClient, maxRequestTime, next, false, false);
+    }
+
+    /**
+     *
+     * @param proxyClient the client to use to make the proxy call
+     * @param maxRequestTime the maximum amount of time to allow the request to be processed
+     * @param next the next handler in line
+     * @param rewriteHostHeader should the HOST header be rewritten to use the target host of the call.
+     * @param reuseXForwarded should any existing X-Forwarded-For header be used or should it be overwritten.
+     */
+    @Deprecated
+    public ProxyHandler(ProxyClient proxyClient, int maxRequestTime, HttpHandler next, boolean rewriteHostHeader, boolean reuseXForwarded) {
+        this(proxyClient, maxRequestTime, next, rewriteHostHeader, reuseXForwarded, DEFAULT_MAX_RETRY_ATTEMPTS);
+    }
+
+    /**
+     * @param proxyClient the client to use to make the proxy call
+     * @param maxRequestTime the maximum amount of time to allow the request to be processed
+     * @param next the next handler in line
+     * @param rewriteHostHeader should the HOST header be rewritten to use the target host of the call.
+     * @param reuseXForwarded should any existing X-Forwarded-For header be used or should it be overwritten.
+     * @param maxConnectionRetries max connection retries.
+     */
+    @Deprecated
+    public ProxyHandler(ProxyClient proxyClient, int maxRequestTime, HttpHandler next, boolean rewriteHostHeader, boolean reuseXForwarded, int maxConnectionRetries) {
+        this.proxyClient = proxyClient;
+        this.maxRequestTime = maxRequestTime;
+        this.next = next;
+        this.rewriteHostHeader = rewriteHostHeader;
+        this.reuseXForwarded = reuseXForwarded;
+        this.maxConnectionRetries = maxConnectionRetries;
+        this.idempotentRequestPredicate = IdempotentPredicate.INSTANCE;
+    }
+
+    @Deprecated
+    public ProxyHandler(ProxyClient proxyClient, HttpHandler next) {
+        this(proxyClient, -1, next);
+    }
+
+    ProxyHandler(Builder builder) {
+        this.proxyClient = builder.proxyClient;
+        this.maxRequestTime = builder.maxRequestTime;
+        this.next = builder.next;
+        this.rewriteHostHeader = builder.rewriteHostHeader;
+        this.reuseXForwarded = builder.reuseXForwarded;
+        this.maxConnectionRetries = builder.maxConnectionRetries;
+        this.idempotentRequestPredicate = builder.idempotentRequestPredicate;
+        for(Map.Entry<HttpString, ExchangeAttribute> e : builder.requestHeaders.entrySet()) {
+            requestHeaders.put(e.getKey(), e.getValue());
+        }
+    }
+
+    public void handleRequest(final HttpServerExchange exchange) throws Exception {
+        final ProxyClient.ProxyTarget target = proxyClient.findTarget(exchange);
+        if (target == null) {
+            log.debug("No proxy target for request to %s", exchange.getRequestURL());
+            next.handleRequest(exchange);
+            return;
+        }
+        if(exchange.isResponseStarted()) {
+            //we can't proxy a request that has already started, this is basically a server configuration error
+            UndertowLogger.REQUEST_LOGGER.cannotProxyStartedRequest(exchange);
+            exchange.setStatusCode(StatusCodes.INTERNAL_SERVER_ERROR);
+            exchange.endExchange();
+            return;
+        }
+        final long timeout = maxRequestTime > 0 ? System.currentTimeMillis() + maxRequestTime : 0;
+        int maxRetries = maxConnectionRetries;
+        if(target instanceof ProxyClient.MaxRetriesProxyTarget) {
+            maxRetries = Math.max(maxRetries, ((ProxyClient.MaxRetriesProxyTarget) target).getMaxRetries());
+        }
+        final ProxyClientHandler clientHandler = new ProxyClientHandler(exchange, target, timeout, maxRetries, idempotentRequestPredicate);
+        if (timeout > 0) {
+            final XnioExecutor.Key key = WorkerUtils.executeAfter(exchange.getIoThread(), new Runnable() {
+                @Override
+                public void run() {
+                    clientHandler.cancel(exchange);
+                }
+            }, maxRequestTime, TimeUnit.MILLISECONDS);
+            exchange.putAttachment(TIMEOUT_KEY, key);
+            exchange.addExchangeCompleteListener(new ExchangeCompletionListener() {
+                @Override
+                public void exchangeEvent(HttpServerExchange exchange, NextListener nextListener) {
+                    key.remove();
+                    nextListener.proceed();
+                }
+            });
+        }
+        exchange.dispatch(exchange.isInIoThread() ? SameThreadExecutor.INSTANCE : exchange.getIoThread(), clientHandler);
+    }
+
+    static void copyHeaders(final HeaderMap to, final HeaderMap from) {
+        long f = from.fastIterateNonEmpty();
+        HeaderValues values;
+        while (f != -1L) {
+            values = from.fiCurrent(f);
+            if(!to.contains(values.getHeaderName())) {
+                //don't over write existing headers, normally the map will be empty, if it is not we assume it is not for a reason
+                to.putAll(values.getHeaderName(), values);
+            }
+            f = from.fiNextNonEmpty(f);
+        }
+    }
+
+    public ProxyClient getProxyClient() {
+        return proxyClient;
+    }
+
+    @Override
+    public String toString() {
+        List<ProxyClient.ProxyTarget> proxyTargets = proxyClient.getAllTargets();
+        if (proxyTargets.isEmpty()){
+            return "ProxyHandler - "+proxyClient.getClass().getSimpleName();
+        }
+        if(proxyTargets.size()==1 && !rewriteHostHeader){
+            return "reverse-proxy( '" + proxyTargets.get(0).toString() + "' )";
+        } else {
+            String outputResult = "reverse-proxy( { '" + proxyTargets.stream().map(s -> s.toString()).collect(Collectors.joining("', '")) + "' }";
+            if(rewriteHostHeader){
+                outputResult += ", rewrite-host-header=true";
+            }
+            return outputResult+" )";
+        }
+    }
+
+    private final class ProxyClientHandler implements ProxyCallback<ProxyConnection>, Runnable {
+
+        private int tries;
+
+        private final long timeout;
+        private final int maxRetryAttempts;
+        private final HttpServerExchange exchange;
+        private final Predicate idempotentPredicate;
+        private ProxyClient.ProxyTarget target;
+
+        ProxyClientHandler(HttpServerExchange exchange, ProxyClient.ProxyTarget target, long timeout, int maxRetryAttempts, Predicate idempotentPredicate) {
+            this.exchange = exchange;
+            this.timeout = timeout;
+            this.maxRetryAttempts = maxRetryAttempts;
+            this.target = target;
+            this.idempotentPredicate = idempotentPredicate;
+        }
+
+        @Override
+        public void run() {
+            proxyClient.getConnection(target, exchange, this, -1, TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public void completed(final HttpServerExchange exchange, final ProxyConnection connection) {
+            exchange.putAttachment(CONNECTION, connection);
+            exchange.dispatch(SameThreadExecutor.INSTANCE, new ProxyAction(connection, exchange, requestHeaders, rewriteHostHeader, reuseXForwarded, exchange.isRequestComplete() ? this : null, idempotentPredicate));
+        }
+
+        @Override
+        public void failed(final HttpServerExchange exchange) {
+            final long time = System.currentTimeMillis();
+            if (tries++ < maxRetryAttempts) {
+                if (timeout > 0 && time > timeout) {
+                    cancel(exchange);
+                } else {
+                    target = proxyClient.findTarget(exchange);
+                    if (target != null) {
+                        final long remaining = timeout > 0 ? timeout - time : -1;
+                        proxyClient.getConnection(target, exchange, this, remaining, TimeUnit.MILLISECONDS);
+                    } else {
+                        couldNotResolveBackend(exchange); // The context was registered when we started, so return 503
+                    }
+                }
+            } else {
+                couldNotResolveBackend(exchange);
+            }
+        }
+
+        @Override
+        public void queuedRequestFailed(HttpServerExchange exchange) {
+            failed(exchange);
+        }
+
+        @Override
+        public void couldNotResolveBackend(HttpServerExchange exchange) {
+            if (exchange.isResponseStarted()) {
+                IoUtils.safeClose(exchange.getConnection());
+            } else {
+                exchange.setStatusCode(StatusCodes.SERVICE_UNAVAILABLE);
+                exchange.endExchange();
+            }
+        }
+
+        void cancel(final HttpServerExchange exchange) {
+            final ProxyConnection connectionAttachment = exchange.getAttachment(CONNECTION);
+            if (connectionAttachment != null) {
+                ClientConnection clientConnection = connectionAttachment.getConnection();
+                UndertowLogger.PROXY_REQUEST_LOGGER.timingOutRequest(clientConnection.getPeerAddress() + "" + exchange.getRequestURI());
+                IoUtils.safeClose(clientConnection);
+            } else {
+                UndertowLogger.PROXY_REQUEST_LOGGER.timingOutRequest(exchange.getRequestURI());
+            }
+            if (exchange.isResponseStarted()) {
+                IoUtils.safeClose(exchange.getConnection());
+            } else {
+                exchange.setStatusCode(StatusCodes.SERVICE_UNAVAILABLE);
+                exchange.endExchange();
+            }
+        }
+
+    }
+
+    private static class ProxyAction implements Runnable {
+        private final ProxyConnection clientConnection;
+        private final HttpServerExchange exchange;
+        private final Map<HttpString, ExchangeAttribute> requestHeaders;
+        private final boolean rewriteHostHeader;
+        private final boolean reuseXForwarded;
+        private final ProxyClientHandler proxyClientHandler;
+        private final Predicate idempotentPredicate;
+
+        ProxyAction(final ProxyConnection clientConnection, final HttpServerExchange exchange, Map<HttpString, ExchangeAttribute> requestHeaders,
+                    boolean rewriteHostHeader, boolean reuseXForwarded, ProxyClientHandler proxyClientHandler, Predicate idempotentPredicate) {
+            this.clientConnection = clientConnection;
+            this.exchange = exchange;
+            this.requestHeaders = requestHeaders;
+            this.rewriteHostHeader = rewriteHostHeader;
+            this.reuseXForwarded = reuseXForwarded;
+            this.proxyClientHandler = proxyClientHandler;
+            this.idempotentPredicate = idempotentPredicate;
+        }
+
+        @Override
+        public void run() {
+            final ClientRequest request = new ClientRequest();
+
+            String targetURI = exchange.getRequestURI();
+            if(exchange.isHostIncludedInRequestURI()) {
+                int uriPart = targetURI.indexOf("//");
+                if(uriPart != -1) {
+                    uriPart = targetURI.indexOf("/", uriPart + 2);
+                    if(uriPart != -1) {
+                        targetURI = targetURI.substring(uriPart);
+                    }
+                }
+            }
+
+            if(!exchange.getResolvedPath().isEmpty() && targetURI.startsWith(exchange.getResolvedPath())) {
+                targetURI = targetURI.substring(exchange.getResolvedPath().length());
+            }
+
+            StringBuilder requestURI = new StringBuilder();
+            if(!clientConnection.getTargetPath().isEmpty()
+                    && (!clientConnection.getTargetPath().equals("/") || targetURI.isEmpty())) {
+                requestURI.append(clientConnection.getTargetPath());
+            }
+            requestURI.append(targetURI);
+
+            String qs = exchange.getQueryString();
+            if (qs != null && !qs.isEmpty()) {
+                requestURI.append('?');
+                requestURI.append(qs);
+            }
+            request.setPath(requestURI.toString())
+                    .setMethod(exchange.getRequestMethod());
+            final HeaderMap inboundRequestHeaders = exchange.getRequestHeaders();
+            final HeaderMap outboundRequestHeaders = request.getRequestHeaders();
+            copyHeaders(outboundRequestHeaders, inboundRequestHeaders);
+
+            if (!exchange.isPersistent()) {
+                //just because the client side is non-persistent
+                //we don't want to close the connection to the backend
+                outboundRequestHeaders.put(Headers.CONNECTION, "keep-alive");
+            }
+            if("h2c".equals(exchange.getRequestHeaders().getFirst(Headers.UPGRADE))) {
+                //we don't allow h2c upgrade requests to be passed through to the backend
+                exchange.getRequestHeaders().remove(Headers.UPGRADE);
+                outboundRequestHeaders.put(Headers.CONNECTION, "keep-alive");
+            }
+
+            for (Map.Entry<HttpString, ExchangeAttribute> entry : requestHeaders.entrySet()) {
+                String headerValue = entry.getValue().readAttribute(exchange);
+                if (headerValue == null || headerValue.isEmpty()) {
+                    outboundRequestHeaders.remove(entry.getKey());
+                } else {
+                    outboundRequestHeaders.put(entry.getKey(), headerValue.replace('\n', ' '));
+                }
+            }
+            final String remoteHost;
+            final SocketAddress address = exchange.getSourceAddress();
+            if (address != null) {
+                remoteHost = ((InetSocketAddress) address).getHostString();
+                if(!((InetSocketAddress) address).isUnresolved()) {
+                    request.putAttachment(ProxiedRequestAttachments.REMOTE_ADDRESS, ((InetSocketAddress) address).getAddress().getHostAddress());
+                }
+            } else {
+                //should never happen, unless this is some form of mock request
+                remoteHost = "localhost";
+            }
+
+            request.putAttachment(ProxiedRequestAttachments.REMOTE_HOST, remoteHost);
+
+            if (reuseXForwarded && request.getRequestHeaders().contains(Headers.X_FORWARDED_FOR)) {
+                // We have an existing header so we shall simply append the host to the existing list
+                final String current = request.getRequestHeaders().getFirst(Headers.X_FORWARDED_FOR);
+                if (current == null || current.isEmpty()) {
+                    // It was empty so just add it
+                    request.getRequestHeaders().put(Headers.X_FORWARDED_FOR, remoteHost);
+                }
+                else {
+                    // Add the new entry and reset the existing header
+                    request.getRequestHeaders().put(Headers.X_FORWARDED_FOR, current + "," + remoteHost);
+                }
+            }
+            else {
+                // No existing header or not allowed to reuse the header so set it here
+                request.getRequestHeaders().put(Headers.X_FORWARDED_FOR, remoteHost);
+            }
+
+            //if we don't support push set a header saying so
+            //this is non standard, and a problem with the HTTP2 spec, but they did not want to listen
+            if(!exchange.getConnection().isPushSupported() && clientConnection.getConnection().isPushSupported()) {
+                request.getRequestHeaders().put(Headers.X_DISABLE_PUSH, "true");
+            }
+
+            // Set the protocol header and attachment
+            if(reuseXForwarded && exchange.getRequestHeaders().contains(Headers.X_FORWARDED_PROTO)) {
+                final String proto = exchange.getRequestHeaders().getFirst(Headers.X_FORWARDED_PROTO);
+                request.putAttachment(ProxiedRequestAttachments.IS_SSL, proto.equals("https"));
+            } else {
+                final String proto = exchange.getRequestScheme().equals("https") ? "https" : "http";
+                request.getRequestHeaders().put(Headers.X_FORWARDED_PROTO, proto);
+                request.putAttachment(ProxiedRequestAttachments.IS_SSL, proto.equals("https"));
+            }
+
+            // Set the server name
+            if(reuseXForwarded && exchange.getRequestHeaders().contains(Headers.X_FORWARDED_SERVER)) {
+                final String hostName = exchange.getRequestHeaders().getFirst(Headers.X_FORWARDED_SERVER);
+                request.putAttachment(ProxiedRequestAttachments.SERVER_NAME, hostName);
+            } else {
+                final String hostName = exchange.getHostName();
+                request.getRequestHeaders().put(Headers.X_FORWARDED_SERVER, hostName);
+                request.putAttachment(ProxiedRequestAttachments.SERVER_NAME, hostName);
+            }
+            if(!exchange.getRequestHeaders().contains(Headers.X_FORWARDED_HOST)) {
+                final String hostName = exchange.getHostName();
+                if(hostName != null) {
+                    request.getRequestHeaders().put(Headers.X_FORWARDED_HOST, NetworkUtils.formatPossibleIpv6Address(hostName));
+                }
+            }
+
+            // Set the port
+            if(reuseXForwarded && exchange.getRequestHeaders().contains(Headers.X_FORWARDED_PORT)) {
+                try {
+                    int port = Integer.parseInt(exchange.getRequestHeaders().getFirst(Headers.X_FORWARDED_PORT));
+                    request.putAttachment(ProxiedRequestAttachments.SERVER_PORT, port);
+                } catch (NumberFormatException e) {
+                    int port = exchange.getConnection().getLocalAddress(InetSocketAddress.class).getPort();
+                    request.getRequestHeaders().put(Headers.X_FORWARDED_PORT, port);
+                    request.putAttachment(ProxiedRequestAttachments.SERVER_PORT, port);
+                }
+            } else {
+                int port = exchange.getHostPort();
+                request.getRequestHeaders().put(Headers.X_FORWARDED_PORT, port);
+                request.putAttachment(ProxiedRequestAttachments.SERVER_PORT, port);
+            }
+
+            SSLSessionInfo sslSessionInfo = exchange.getConnection().getSslSessionInfo();
+            if (sslSessionInfo != null) {
+                Certificate[] peerCertificates;
+                try {
+                    peerCertificates = sslSessionInfo.getPeerCertificates();
+                    if (peerCertificates.length > 0) {
+                        request.putAttachment(ProxiedRequestAttachments.SSL_CERT, Certificates.toPem(peerCertificates[0]));
+                    }
+                } catch (SSLPeerUnverifiedException | CertificateEncodingException | RenegotiationRequiredException e) {
+                    //ignore
+                }
+                request.putAttachment(ProxiedRequestAttachments.SSL_CYPHER, sslSessionInfo.getCipherSuite());
+                request.putAttachment(ProxiedRequestAttachments.SSL_SESSION_ID, sslSessionInfo.getSessionId());
+                request.putAttachment(ProxiedRequestAttachments.SSL_KEY_SIZE, sslSessionInfo.getKeySize());
+            }
+
+            if(rewriteHostHeader) {
+                InetSocketAddress targetAddress = clientConnection.getConnection().getPeerAddress(InetSocketAddress.class);
+                request.getRequestHeaders().put(Headers.HOST, targetAddress.getHostString() + ":" + targetAddress.getPort());
+                request.getRequestHeaders().put(Headers.X_FORWARDED_HOST, exchange.getRequestHeaders().getFirst(Headers.HOST));
+            }
+            if(log.isDebugEnabled()) {
+                log.debug("Sending request %s to target %s for exchange %s", request, clientConnection.getConnection().getPeerAddress(), exchange);
+            }
+            //handle content
+            //if the frontend is HTTP/2 then we may need to add a Transfer-Encoding header, to indicate to the backend
+            //that there is content
+            if(!request.getRequestHeaders().contains(Headers.TRANSFER_ENCODING) && !request.getRequestHeaders().contains(Headers.CONTENT_LENGTH)) {
+                if(!exchange.isRequestComplete()) {
+                    request.getRequestHeaders().put(Headers.TRANSFER_ENCODING, Headers.CHUNKED.toString());
+                }
+            }
+
+
+            clientConnection.getConnection().sendRequest(request, new ClientCallback<ClientExchange>() {
+                @Override
+                public void completed(final ClientExchange result) {
+
+                    if(log.isDebugEnabled()) {
+                        log.debug("Sent request %s to target %s for exchange %s", request, remoteHost, exchange);
+                    }
+                    result.putAttachment(EXCHANGE, exchange);
+
+                    boolean requiresContinueResponse = HttpContinue.requiresContinueResponse(exchange);
+                    if (requiresContinueResponse) {
+                        result.setContinueHandler(new ContinueNotification() {
+                            @Override
+                            public void handleContinue(final ClientExchange clientExchange) {
+                                if(log.isDebugEnabled()) {
+                                    log.debug("Received continue response to request %s to target %s for exchange %s", request, clientConnection.getConnection().getPeerAddress(), exchange);
+                                }
+                                HttpContinue.sendContinueResponse(exchange, new IoCallback() {
+                                    @Override
+                                    public void onComplete(final HttpServerExchange exchange, final Sender sender) {
+                                        //don't care
+                                    }
+
+                                    @Override
+                                    public void onException(final HttpServerExchange exchange, final Sender sender, final IOException exception) {
+                                        IoUtils.safeClose(clientConnection.getConnection());
+                                        exchange.endExchange();
+                                        UndertowLogger.REQUEST_IO_LOGGER.ioException(exception);
+                                    }
+                                });
+                            }
+                        });
+                    }
+
+                    //handle server push
+                    if(exchange.getConnection().isPushSupported() && result.getConnection().isPushSupported()) {
+                        result.setPushHandler(new PushCallback() {
+                            @Override
+                            public boolean handlePush(ClientExchange originalRequest, final ClientExchange pushedRequest) {
+
+                                if(log.isDebugEnabled()) {
+                                    log.debug("Sending push request %s received from %s to target %s for exchange %s", pushedRequest.getRequest(), request, remoteHost, exchange);
+                                }
+                                final ClientRequest request = pushedRequest.getRequest();
+                                exchange.getConnection().pushResource(request.getPath(), request.getMethod(), request.getRequestHeaders(), new HttpHandler() {
+                                    @Override
+                                    public void handleRequest(final HttpServerExchange exchange) throws Exception {
+                                        String path = request.getPath();
+                                        int i = path.indexOf("?");
+                                        if(i > 0) {
+                                            path = path.substring(0, i);
+                                        }
+
+                                        exchange.dispatch(SameThreadExecutor.INSTANCE, new ProxyAction(new ProxyConnection(pushedRequest.getConnection(), path), exchange, requestHeaders, rewriteHostHeader, reuseXForwarded, null, idempotentPredicate));
+                                    }
+                                });
+                                return true;
+                            }
+                        });
+                    }
+
+
+                    result.setResponseListener(new ResponseCallback(exchange, proxyClientHandler, idempotentPredicate));
+                    final IoExceptionHandler handler = new IoExceptionHandler(exchange, clientConnection.getConnection());
+                    if(requiresContinueResponse) {
+                        try {
+                            if(!result.getRequestChannel().flush()) {
+                                result.getRequestChannel().getWriteSetter().set(ChannelListeners.flushingChannelListener(new ChannelListener<StreamSinkChannel>() {
+                                    @Override
+                                    public void handleEvent(StreamSinkChannel channel) {
+                                        Transfer.initiateTransfer(exchange.getRequestChannel(), result.getRequestChannel(), ChannelListeners.closingChannelListener(), new HTTPTrailerChannelListener(exchange, result, exchange, proxyClientHandler, idempotentPredicate), handler, handler, exchange.getConnection().getByteBufferPool());
+
+                                    }
+                                }, handler));
+                                result.getRequestChannel().resumeWrites();
+                                return;
+                            }
+                        } catch (IOException e) {
+                            handler.handleException(result.getRequestChannel(), e);
+                        }
+                    }
+                    HTTPTrailerChannelListener trailerListener = new HTTPTrailerChannelListener(exchange, result, exchange, proxyClientHandler, idempotentPredicate);
+                    if(!exchange.isRequestComplete()) {
+                        Transfer.initiateTransfer(exchange.getRequestChannel(), result.getRequestChannel(), ChannelListeners.closingChannelListener(), trailerListener, handler, handler, exchange.getConnection().getByteBufferPool());
+                    } else {
+                        trailerListener.handleEvent(result.getRequestChannel());
+                    }
+
+                }
+
+                @Override
+                public void failed(IOException e) {
+                    handleFailure(exchange, proxyClientHandler, idempotentPredicate, e);
+                }
+            });
+
+
+        }
+    }
+
+    static void handleFailure(HttpServerExchange exchange, ProxyClientHandler proxyClientHandler, Predicate idempotentRequestPredicate, IOException e) {
+        UndertowLogger.PROXY_REQUEST_LOGGER.proxyRequestFailed(exchange.getRequestURI(), e);
+        if(exchange.isResponseStarted()) {
+            IoUtils.safeClose(exchange.getConnection());
+        } else if(idempotentRequestPredicate.resolve(exchange) && proxyClientHandler != null) {
+            proxyClientHandler.failed(exchange); //this will attempt a retry if configured to do so
+        } else {
+            exchange.setStatusCode(StatusCodes.SERVICE_UNAVAILABLE);
+            exchange.endExchange();
+        }
+    }
+
+    private static final class ResponseCallback implements ClientCallback<ClientExchange> {
+
+        private final HttpServerExchange exchange;
+        private final ProxyClientHandler proxyClientHandler;
+        private final Predicate idempotentPredicate;
+
+        private ResponseCallback(HttpServerExchange exchange, ProxyClientHandler proxyClientHandler, Predicate idempotentPredicate) {
+            this.exchange = exchange;
+            this.proxyClientHandler = proxyClientHandler;
+            this.idempotentPredicate = idempotentPredicate;
+        }
+
+        @Override
+        public void completed(final ClientExchange result) {
+
+            final ClientResponse response = result.getResponse();
+
+            if(log.isDebugEnabled()) {
+                log.debug("Received response %s for request %s for exchange %s", response, result.getRequest(), exchange);
+            }
+            final HeaderMap inboundResponseHeaders = response.getResponseHeaders();
+            final HeaderMap outboundResponseHeaders = exchange.getResponseHeaders();
+            exchange.setStatusCode(response.getResponseCode());
+            copyHeaders(outboundResponseHeaders, inboundResponseHeaders);
+
+            if (exchange.isUpgrade()) {
+
+                exchange.upgradeChannel(new HttpUpgradeListener() {
+                    @Override
+                    public void handleUpgrade(StreamConnection streamConnection, HttpServerExchange exchange) {
+
+                        if(log.isDebugEnabled()) {
+                            log.debug("Upgraded request %s to for exchange %s", result.getRequest(), exchange);
+                        }
+                        StreamConnection clientChannel = null;
+                        try {
+                            clientChannel = result.getConnection().performUpgrade();
+
+                            final ClosingExceptionHandler handler = new ClosingExceptionHandler(streamConnection, clientChannel);
+                            Transfer.initiateTransfer(clientChannel.getSourceChannel(), streamConnection.getSinkChannel(), ChannelListeners.closingChannelListener(), ChannelListeners.writeShutdownChannelListener(ChannelListeners.<StreamSinkChannel>flushingChannelListener(ChannelListeners.closingChannelListener(), ChannelListeners.closingChannelExceptionHandler()), ChannelListeners.closingChannelExceptionHandler()), handler, handler, result.getConnection().getBufferPool());
+                            Transfer.initiateTransfer(streamConnection.getSourceChannel(), clientChannel.getSinkChannel(), ChannelListeners.closingChannelListener(), ChannelListeners.writeShutdownChannelListener(ChannelListeners.<StreamSinkChannel>flushingChannelListener(ChannelListeners.closingChannelListener(), ChannelListeners.closingChannelExceptionHandler()), ChannelListeners.closingChannelExceptionHandler()), handler, handler, result.getConnection().getBufferPool());
+
+                        } catch (IOException e) {
+                            IoUtils.safeClose(streamConnection, clientChannel);
+                        }
+                    }
+                });
+            }
+            final IoExceptionHandler handler = new IoExceptionHandler(exchange, result.getConnection());
+            Transfer.initiateTransfer(result.getResponseChannel(), exchange.getResponseChannel(), ChannelListeners.closingChannelListener(), new HTTPTrailerChannelListener(result, exchange, exchange, proxyClientHandler, idempotentPredicate), handler, handler, exchange.getConnection().getByteBufferPool());
+        }
+
+        @Override
+        public void failed(IOException e) {
+            handleFailure(exchange, proxyClientHandler, idempotentPredicate, e);
+        }
+    }
+
+    private static final class HTTPTrailerChannelListener implements ChannelListener<StreamSinkChannel> {
+
+        private final Attachable source;
+        private final Attachable target;
+        private final HttpServerExchange exchange;
+        private final ProxyClientHandler proxyClientHandler;
+        private final Predicate idempotentPredicate;
+
+        private HTTPTrailerChannelListener(final Attachable source, final Attachable target, HttpServerExchange exchange, ProxyClientHandler proxyClientHandler, Predicate idempotentPredicate) {
+            this.source = source;
+            this.target = target;
+            this.exchange = exchange;
+            this.proxyClientHandler = proxyClientHandler;
+            this.idempotentPredicate = idempotentPredicate;
+        }
+
+        @Override
+        public void handleEvent(final StreamSinkChannel channel) {
+            HeaderMap trailers = source.getAttachment(HttpAttachments.REQUEST_TRAILERS);
+            if (trailers != null) {
+                target.putAttachment(HttpAttachments.RESPONSE_TRAILERS, trailers);
+            }
+            try {
+                channel.shutdownWrites();
+                if (!channel.flush()) {
+                    channel.getWriteSetter().set(ChannelListeners.flushingChannelListener(new ChannelListener<StreamSinkChannel>() {
+                        @Override
+                        public void handleEvent(StreamSinkChannel channel) {
+                            channel.suspendWrites();
+                            channel.getWriteSetter().set(null);
+                        }
+                    }, ChannelListeners.closingChannelExceptionHandler()));
+                    channel.resumeWrites();
+                } else {
+                    channel.getWriteSetter().set(null);
+                    channel.shutdownWrites();
+                }
+            } catch (IOException e) {
+                handleFailure(exchange, proxyClientHandler, idempotentPredicate, e);
+            } catch (Exception e) {
+                handleFailure(exchange, proxyClientHandler, idempotentPredicate, new IOException(e));
+            }
+
+        }
+    }
+
+    private static final class IoExceptionHandler implements ChannelExceptionHandler<Channel> {
+
+        private final HttpServerExchange exchange;
+        private final ClientConnection clientConnection;
+
+        private IoExceptionHandler(HttpServerExchange exchange, ClientConnection clientConnection) {
+            this.exchange = exchange;
+            this.clientConnection = clientConnection;
+        }
+
+        @Override
+        public void handleException(Channel channel, IOException exception) {
+            IoUtils.safeClose(channel);
+            IoUtils.safeClose(clientConnection);
+            if (exchange.isResponseStarted()) {
+                UndertowLogger.REQUEST_IO_LOGGER.debug("Exception reading from target server", exception);
+                if (!exchange.isResponseStarted()) {
+                    exchange.setStatusCode(StatusCodes.INTERNAL_SERVER_ERROR);
+                    exchange.endExchange();
+                } else {
+                    IoUtils.safeClose(exchange.getConnection());
+                }
+            } else {
+                UndertowLogger.REQUEST_IO_LOGGER.ioException(exception);
+                exchange.setStatusCode(StatusCodes.INTERNAL_SERVER_ERROR);
+                exchange.endExchange();
+            }
+        }
+    }
+
+    public int getMaxConnectionRetries() {
+        return maxConnectionRetries;
+    }
+
+    public Predicate getIdempotentRequestPredicate() {
+        return idempotentRequestPredicate;
+    }
+
+    private static final class ClosingExceptionHandler implements ChannelExceptionHandler<Channel> {
+
+        private final Closeable[] toClose;
+
+        private ClosingExceptionHandler(Closeable... toClose) {
+            this.toClose = toClose;
+        }
+
+
+        @Override
+        public void handleException(Channel channel, IOException exception) {
+            IoUtils.safeClose(channel);
+            IoUtils.safeClose(toClose);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private ProxyClient proxyClient;
+        private int maxRequestTime = -1;
+        private final Map<HttpString, ExchangeAttribute> requestHeaders = new CopyOnWriteMap<>();
+        private HttpHandler next = ResponseCodeHandler.HANDLE_404;
+        private boolean rewriteHostHeader;
+        private boolean reuseXForwarded;
+        private int maxConnectionRetries = DEFAULT_MAX_RETRY_ATTEMPTS;
+        private Predicate idempotentRequestPredicate = IdempotentPredicate.INSTANCE;
+
+        Builder() {};
+
+
+        public ProxyClient getProxyClient() {
+            return proxyClient;
+        }
+
+        public Builder setProxyClient(ProxyClient proxyClient) {
+            if(proxyClient == null) {
+                throw UndertowMessages.MESSAGES.argumentCannotBeNull("proxyClient");
+            }
+            this.proxyClient = proxyClient;
+            return this;
+        }
+
+        public int getMaxRequestTime() {
+            return maxRequestTime;
+        }
+
+        public Builder setMaxRequestTime(int maxRequestTime) {
+            this.maxRequestTime = maxRequestTime;
+            return this;
+        }
+
+        public Map<HttpString, ExchangeAttribute> getRequestHeaders() {
+            return Collections.unmodifiableMap(requestHeaders);
+        }
+
+        public Builder addRequestHeader(HttpString header, ExchangeAttribute value) {
+            this.requestHeaders.put(header, value);
+            return this;
+        }
+
+        public HttpHandler getNext() {
+            return next;
+        }
+
+        public Builder setNext(HttpHandler next) {
+            this.next = next;
+            return this;
+        }
+
+        public boolean isRewriteHostHeader() {
+            return rewriteHostHeader;
+        }
+
+        public Builder setRewriteHostHeader(boolean rewriteHostHeader) {
+            this.rewriteHostHeader = rewriteHostHeader;
+            return this;
+        }
+
+        public boolean isReuseXForwarded() {
+            return reuseXForwarded;
+        }
+
+        public Builder setReuseXForwarded(boolean reuseXForwarded) {
+            this.reuseXForwarded = reuseXForwarded;
+            return this;
+        }
+
+        public int getMaxConnectionRetries() {
+            return maxConnectionRetries;
+        }
+
+        public Builder setMaxConnectionRetries(int maxConnectionRetries) {
+            this.maxConnectionRetries = maxConnectionRetries;
+            return this;
+        }
+
+        public Predicate getIdempotentRequestPredicate() {
+            return idempotentRequestPredicate;
+        }
+
+        public Builder setIdempotentRequestPredicate(Predicate idempotentRequestPredicate) {
+            if(idempotentRequestPredicate == null) {
+                throw UndertowMessages.MESSAGES.argumentCannotBeNull("idempotentRequestPredicate");
+            }
+            this.idempotentRequestPredicate = idempotentRequestPredicate;
+            return this;
+        }
+
+        public ProxyHandler build() {
+            return new ProxyHandler(this);
+        }
+    }
+}

--- a/ingress-proxy/src/main/java/com/networknt/proxy/ProxyServerInfoHandler.java
+++ b/ingress-proxy/src/main/java/com/networknt/proxy/ProxyServerInfoHandler.java
@@ -1,0 +1,125 @@
+package com.networknt.proxy;
+
+import com.networknt.client.Http2Client;
+import com.networknt.config.Config;
+import com.networknt.handler.LightHttpHandler;
+import com.networknt.info.ServerInfoGetHandler;
+import com.networknt.utility.StringUtils;
+import io.undertow.UndertowOptions;
+import io.undertow.client.ClientConnection;
+import io.undertow.client.ClientRequest;
+import io.undertow.client.ClientResponse;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderValues;
+import io.undertow.util.Headers;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import org.xnio.OptionMap;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ProxyServerInfoHandler implements LightHttpHandler {
+    static final String CONFIG_NAME = "proxy";
+    static ProxyConfig config = (ProxyConfig) Config.getInstance().getJsonObjectConfig(CONFIG_NAME, ProxyConfig.class);
+    private static Http2Client client = Http2Client.getInstance();
+    private static final int UNUSUAL_STATUS_CODE = 300;
+    private static OptionMap optionMap = OptionMap.create(UndertowOptions.ENABLE_HTTP2, true);
+    private static final String PROXY_INFO_KEY = "proxy_info";
+
+    public ProxyServerInfoHandler() {
+        config = (ProxyConfig) Config.getInstance().getJsonObjectConfig(CONFIG_NAME, ProxyConfig.class);
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        Map<String, Object> result = new HashMap<>();
+        Map<String, Object> proxyInfo = ServerInfoGetHandler.getServerInfo(exchange);
+        result.put(PROXY_INFO_KEY, proxyInfo);
+        HeaderValues authVal = exchange.getRequestHeaders().get(Headers.AUTHORIZATION_STRING);
+        String token = authVal == null ? "" : authVal.get(0);
+        List<String> urls = Arrays.asList(config.getHosts().split(","));
+        for (String url : urls) {
+            Map<String, Object> serverInfo;
+            try {
+                String serverInfoStr = getServerInfo(url, token);
+                serverInfo = Config.getInstance().getMapper().readValue(serverInfoStr, Map.class);
+            } catch (Exception e) {
+                logger.error("cannot get server info for " + url, e);
+                serverInfo = null;
+            }
+            result.put(url, serverInfo);
+        }
+        exchange.getResponseSender().send(Config.getInstance().getMapper().writeValueAsString(result));
+
+    }
+
+    /**
+     * get server info from url with token
+     * @param url the url of the target server
+     * @param token auth token
+     * @return server info JSON string
+     */
+    public static String getServerInfo(String url, String token) {
+
+        String res = "{}";
+        ClientConnection connection = null;
+        try {
+            URI uri = new URI(url);
+            if (config == null || !config.isHttpsEnabled()) {
+                connection = client.borrowConnection(uri, Http2Client.WORKER, Http2Client.BUFFER_POOL, OptionMap.EMPTY).get();
+            } else {
+                connection = client.borrowConnection(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap).get();
+            }
+
+            AtomicReference<ClientResponse> reference = send(connection, Methods.GET, "/server/info", token, null);
+            if(reference != null && reference.get() != null) {
+                int statusCode = reference.get().getResponseCode();
+                if (statusCode >= UNUSUAL_STATUS_CODE) {
+                    logger.error("Server Info error: {} : {}", statusCode, reference.get().getAttachment(Http2Client.RESPONSE_BODY));
+                    throw new RuntimeException();
+                } else {
+                    res = reference.get().getAttachment(Http2Client.RESPONSE_BODY);
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Server info request exception", e);
+            throw new RuntimeException("exception when getting server info", e);
+        } finally {
+            client.returnConnection(connection);
+        }
+        return res;
+    }
+
+    /**
+     * send to service from controller with the health check and server info
+     *
+     * @param connection ClientConnection
+     * @param path       path to send to controller
+     * @param token      token to put in header
+     * @return AtomicReference<ClientResponse> response
+     */
+    private static AtomicReference<ClientResponse> send(ClientConnection connection, HttpString method, String path, String token, String json) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<ClientResponse> reference = new AtomicReference<>();
+        ClientRequest request = new ClientRequest().setMethod(method).setPath(path);
+        // add host header for HTTP/1.1 server when HTTP is used.
+        request.getRequestHeaders().put(Headers.HOST, "localhost");
+        if (token != null) request.getRequestHeaders().put(Headers.AUTHORIZATION, "Bearer "  + token);
+        if(StringUtils.isBlank(json)) {
+            connection.sendRequest(request, client.createClientCallback(reference, latch));
+        } else {
+            request.getRequestHeaders().put(Headers.CONTENT_TYPE, "application/json");
+            request.getRequestHeaders().put(Headers.TRANSFER_ENCODING, "chunked");
+            connection.sendRequest(request, client.createClientCallback(reference, latch, json));
+        }
+        latch.await(1000, TimeUnit.MILLISECONDS);
+        return reference;
+    }
+}

--- a/ingress-proxy/src/main/resources/proxy.yml
+++ b/ingress-proxy/src/main/resources/proxy.yml
@@ -1,0 +1,26 @@
+---
+# Reverse Proxy Handler Configuration
+
+# If HTTP 2.0 protocol will be used to connect to target servers
+http2Enabled: false
+
+# If TLS is enabled when connecting to the target servers
+httpsEnabled: false
+
+# Target URIs
+hosts: http://localhost:8081
+
+# Connections per thread to the target servers
+connectionsPerThread: 20
+
+# Max request time in milliseconds before timeout
+maxRequestTime: 1000
+
+# Rewrite Host Header with the target host and port and write X_FORWARDED_HOST with original host
+rewriteHostHeader: true
+
+# Reuse XForwarded for the target XForwarded header
+reuseXForwarded: false
+
+# Max Connection Retries
+maxConnectionRetries: 3

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,8 @@
         <module>logger-config</module>
         <module>jaeger-tracing</module>
         <module>http-entity</module>
+        <module>egress-router</module>
+        <module>ingress-proxy</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
add two new modules: one for router handlers and another one for proxy handlers.

The light-router / light-proxy /light-mesh will use dependency on these modules instead of have the handlers in the project