### PR TITLE
fixes #995

### DIFF
--- a/egress-router/src/main/resources/config/token.yml
+++ b/egress-router/src/main/resources/config/token.yml
@@ -1,0 +1,2 @@
+enabled: false
+scopeToken: true


### PR DESCRIPTION
Add defaule token.yaml config to egress-router module.

the default enable setting is false. User can enable it if the router need handler token by handlers:

SAMLTokenHandler

TokenHandler