### PR TITLE
Inefficient Usages of Java Collections

### DIFF
--- a/config/src/main/java/com/networknt/config/ConfigInjection.java
+++ b/config/src/main/java/com/networknt/config/ConfigInjection.java
@@ -82,10 +82,16 @@ public class ConfigInjection {
     // Return the list of exclusion files list which includes the names of config files that shouldn't be injected
     // Double check values and exclusions to ensure no dead loop
     public static boolean isExclusionConfigFile(String configName) {
-        List<Object> exclusionConfigFileList = (exclusionMap == null) ? new ArrayList<>() : (List<Object>) exclusionMap.get(EXCLUSION_CONFIG_FILE_LIST);
+        HashSet<Object> exclusionConfigFileSet;
+        if (exclusionMap == null || !exclusionMap.containsKey(EXCLUSION_CONFIG_FILE_LIST)) {
+            exclusionConfigFileSet = new HashSet<>();
+        } else {
+            exclusionMap.put(EXCLUSION_CONFIG_FILE_LIST, new HashSet(exclusionMap.get(EXCLUSION_CONFIG_FILE_LIST)));
+            exclusionConfigFileSet = exclusionMap.get(EXCLUSION_CONFIG_FILE_LIST);
+        }
         return CENTRALIZED_MANAGEMENT.equals(configName)
                 || SCALABLE_CONFIG.equals(configName)
-                || exclusionConfigFileList.contains(configName);
+                || exclusionConfigFileSet.contains(configName);
     }
 
     // Method used to parse the content inside pattern "${}"

--- a/config/src/main/java/com/networknt/config/ConfigInjection.java
+++ b/config/src/main/java/com/networknt/config/ConfigInjection.java
@@ -86,8 +86,12 @@ public class ConfigInjection {
         if (exclusionMap == null || !exclusionMap.containsKey(EXCLUSION_CONFIG_FILE_LIST)) {
             exclusionConfigFileSet = new HashSet<>();
         } else {
-            exclusionMap.put(EXCLUSION_CONFIG_FILE_LIST, new HashSet(exclusionMap.get(EXCLUSION_CONFIG_FILE_LIST)));
-            exclusionConfigFileSet = exclusionMap.get(EXCLUSION_CONFIG_FILE_LIST);
+            if (exclusionMap.get(EXCLUSION_CONFIG_FILE_LIST) instanceof Set) {
+                exclusionConfigFileSet = exclusionMap.get(EXCLUSION_CONFIG_FILE_LIST);
+            } else {
+                exclusionMap.put(EXCLUSION_CONFIG_FILE_LIST, new HashSet(exclusionMap.get(EXCLUSION_CONFIG_FILE_LIST)));
+                exclusionConfigFileSet = exclusionMap.get(EXCLUSION_CONFIG_FILE_LIST);
+            }
         }
         return CENTRALIZED_MANAGEMENT.equals(configName)
                 || SCALABLE_CONFIG.equals(configName)

--- a/ip-whitelist/src/main/java/com/networknt/whitelist/IpAcl.java
+++ b/ip-whitelist/src/main/java/com/networknt/whitelist/IpAcl.java
@@ -16,12 +16,12 @@
 
 package com.networknt.whitelist;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 public class IpAcl {
-    private List<WhitelistHandler.PeerMatch> ipv6acl = new ArrayList<>();
-    private List<WhitelistHandler.PeerMatch> ipv4acl = new ArrayList<>();
+    private List<WhitelistHandler.PeerMatch> ipv6acl = new LinkedList<>();
+    private List<WhitelistHandler.PeerMatch> ipv4acl = new LinkedList<>();
 
     public List<WhitelistHandler.PeerMatch> getIpv6acl() {
         return ipv6acl;

--- a/sanitizer/src/main/java/com/networknt/sanitizer/enconding/Encoder.java
+++ b/sanitizer/src/main/java/com/networknt/sanitizer/enconding/Encoder.java
@@ -1,7 +1,9 @@
 package com.networknt.sanitizer.enconding;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Map;
 
 public class Encoder {
@@ -17,12 +19,14 @@ public class Encoder {
     }
 
     public void encodeNode(Map<String, Object> map) {
+        Set<String> attributesToIgnoreSet = new HashSet<>(attributesToIgnore);
+        Set<String> attributesToAppreciateSet = new HashSet<>(attributesToAppreciate);
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             String key = entry.getKey();
-            if (attributesToIgnore.contains(key)) {
+            if (attributesToIgnoreSet.contains(key)) {
                 continue;
             }
-            if (!attributesToAppreciate.isEmpty() && !attributesToAppreciate.contains(key)) {
+            if (!attributesToAppreciateSet.isEmpty() && !attributesToAppreciateSet.contains(key)) {
                 continue;
             }
 


### PR DESCRIPTION
Hi,
We find that the List allocated at line 85 in the function `isExclusionConfigFile` is only used to check whether an element is stored in the container. The method `contains` of a list runs in linear time complexity. We notice that the `exclusionFileList` is maintained in the HashMap `exclusionMap`, which maps a string object to an object.

To achieve the same functionality, maybe a `HashSet` can provide a more efficient implementation. We can just construct a HashSet and maintain it in the HashMap `exclusionMap`. When we invoke the function `isExclusionConfigFile`, we only need to take amortized O(1) time to maintain the map and invoke the `contains` method of `HashSet`.

We discovered this inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well. Of course, it would be better to change `EXCLUSION_CONFIG_FILE_LIST` to `EXCLUSION_CONFIG_FILE_Set`. Anyway, the name does not affect the performance anymore.

Bests

Ditto