### PR TITLE
Feature/dependency update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
         <version.jose4j>0.6.3</version.jose4j>
         <version.commons.codec>1.13</version.commons.codec>
         <version.encoder>1.2.1</version.encoder>
-        <versions.xnio>3.8.5.Final</versions.xnio>
         <version.logback>1.2.7</version.logback>
         <version.junit>4.13.1</version.junit>
         <version.mockito>2.23.0</version.mockito>
@@ -466,16 +465,6 @@
                 <groupId>org.jboss.threads</groupId>
                 <artifactId>jboss-threads</artifactId>
                 <version>3.4.2.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.xnio</groupId>
-                <artifactId>xnio-nio</artifactId>
-                <version>${versions.xnio}}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.xnio</groupId>
-                <artifactId>xnio-api</artifactId>
-                <version>${versions.xnio}}</version>
             </dependency>
             <dependency>
                 <groupId>org.hdrhistogram</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,9 +69,9 @@
         <version.jackson>2.12.1</version.jackson>
         <version.slf4j>1.7.25</version.slf4j>
         <version.jose4j>0.6.3</version.jose4j>
-        <version.commons.codec>1.11</version.commons.codec>
+        <version.commons.codec>1.13</version.commons.codec>
         <version.encoder>1.2.1</version.encoder>
-        <version.logback>1.2.3</version.logback>
+        <version.logback>1.2.7</version.logback>
         <version.junit>4.13.1</version.junit>
         <version.mockito>2.23.0</version.mockito>
         <version.powermock>2.0.2</version.powermock>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <version.jose4j>0.6.3</version.jose4j>
         <version.commons.codec>1.13</version.commons.codec>
         <version.encoder>1.2.1</version.encoder>
+        <versions.xnio>3.8.5.Final</versions.xnio>
         <version.logback>1.2.7</version.logback>
         <version.junit>4.13.1</version.junit>
         <version.mockito>2.23.0</version.mockito>
@@ -464,7 +465,17 @@
             <dependency>
                 <groupId>org.jboss.threads</groupId>
                 <artifactId>jboss-threads</artifactId>
-                <version>2.3.2.Final</version>
+                <version>3.4.2.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.xnio</groupId>
+                <artifactId>xnio-nio</artifactId>
+                <version>${versions.xnio}}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.xnio</groupId>
+                <artifactId>xnio-api</artifactId>
+                <version>${versions.xnio}}</version>
             </dependency>
             <dependency>
                 <groupId>org.hdrhistogram</groupId>


### PR DESCRIPTION
**Updated Apache Commons Codec from 1.11 -> 1.13**
- Fixes Apache Commons Invalid Base32 String Tunneling Weakness.

**Updated Logback from 1.2.3 -> 1.2.7**
- Fixes *some* Logback Config File Field Server-side Request Forgery (SSRF) weaknesses.


**Additional Notes**
Logback 1.2.7 still has more issues with request forgery, so we should update to 1.3.0 when it gets a full release (it is still 1.3.0-alpha).

The Apache Commons Compress dependency has a known security risk with an exception DDOS exploit. The newest release does not fix this issue, so we should keep an eye out for an update. 