### PR TITLE
 implement change to issue #1114

### DIFF
--- a/handler/src/main/java/com/networknt/handler/config/HandlerConfig.java
+++ b/handler/src/main/java/com/networknt/handler/config/HandlerConfig.java
@@ -26,6 +26,7 @@ import java.util.Map;
 public class HandlerConfig {
     private boolean enabled;
     private List<Object> handlers;
+    private Object exceptionProcessor;
     private Map<String, List<String>> chains;
     private List<PathChain> paths;
     private List<String> defaultHandlers;
@@ -43,6 +44,14 @@ public class HandlerConfig {
 
     public List<Object> getHandlers() {
         return handlers;
+    }
+
+    public Object getExceptionProcessor() {
+        return exceptionProcessor;
+    }
+
+    public void setExceptionProcessor(Object exceptionProcessor) {
+        this.exceptionProcessor = exceptionProcessor;
     }
 
     public void setHandlers(List<Object> handlers) {

--- a/handler/src/test/java/com/networknt/handler/HandlerTest.java
+++ b/handler/src/test/java/com/networknt/handler/HandlerTest.java
@@ -16,16 +16,21 @@
 
 package com.networknt.handler;
 
+import com.networknt.exception.ApiException;
 import com.networknt.handler.config.EndpointSource;
 import com.networknt.handler.config.PathChain;
+import com.networknt.status.Status;
 import com.networknt.utility.Tuple;
 import io.undertow.server.HttpHandler;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.PathTemplateMatcher;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
+import java.lang.management.MemoryType;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +57,10 @@ public class HandlerTest {
         Map<String, List<HttpHandler>> handlers = Handler.handlerListById;
         Assert.assertEquals(1, handlers.get("third").size());
         Assert.assertEquals(2, handlers.get("secondBeforeFirst").size());
+
+        Status status = new Status("ERR11618");
+        Method method =  Handler.resolveMethod(new ApiException(status));
+        Assert.assertNotNull(method);
     }
 
     private PathChain mkPathChain(String source, String path, String method, String... exec) {
@@ -61,6 +70,26 @@ public class HandlerTest {
         pc.setMethod(method);
         pc.setExec(Arrays.asList(exec));
         return pc;
+    }
+
+    @Ignore
+    @Test
+    public void testExceptionProcessorMethod() {
+        Handler.init();
+        Status status = new Status("ERR11618");
+        Method method =  Handler.resolveMethod(new ApiException(status));
+        Assert.assertNotNull(method);
+    }
+
+    @Ignore
+    @Test
+    public void testExceptionProcessorMethodInvoke() throws  Exception{
+        Handler.init();
+
+        Status status = new Status("ERR11618");
+        Status result =  Handler.handlerException(new ApiException(status));
+        Assert.assertNotNull(result);
+        Assert.assertEquals("ERR11618", result.getCode());
     }
 
     static class MockEndpointSource implements EndpointSource {

--- a/handler/src/test/resources/handler.yml
+++ b/handler/src/test/resources/handler.yml
@@ -35,3 +35,5 @@ paths:
 # will be returned.
 defaultHandlers:
   - third
+
+exceptionProcessor: com.networknt.exception.DefaultExceptionProcessor

--- a/status/src/main/java/com/networknt/exception/DefaultExceptionProcessor.java
+++ b/status/src/main/java/com/networknt/exception/DefaultExceptionProcessor.java
@@ -1,0 +1,40 @@
+package com.networknt.exception;
+
+import com.networknt.status.Status;
+
+/**
+ * Defualt Exception processor for the API exceptions. If user doesn't set the Exception processor in the handler.yml
+ * API will use this for exception handler.
+ * User defined Exception processor should extends from this default processor
+ */
+public class DefaultExceptionProcessor {
+
+    static final String STATUS_UNCAUGHT_EXCEPTION = "ERR10011";
+    static final String TOKEN_EXPIRED = "ERR10004";
+
+    @ExceptionIndicator(value = FrameworkException.class)
+    public Status exception(FrameworkException exception) {
+        return exception.getStatus();
+    }
+
+    @ExceptionIndicator(value = ApiException.class)
+    public Status exception(ApiException exception) {
+        return exception.getStatus();
+    }
+
+    @ExceptionIndicator(value = ClientException.class)
+    public Status exception(ClientException exception) {
+        if(exception.getStatus().getStatusCode() == 0){
+            return new Status(STATUS_UNCAUGHT_EXCEPTION);
+        } else {
+            return exception.getStatus();
+        }
+    }
+
+    @ExceptionIndicator(value = ExpiredTokenException.class)
+    public Status exception(ExpiredTokenException exception) {
+        Status status = new Status(TOKEN_EXPIRED);
+        status.setMessage(exception.getMessage());
+        return status;
+    }
+}

--- a/status/src/main/java/com/networknt/exception/ExceptionDepthComparator.java
+++ b/status/src/main/java/com/networknt/exception/ExceptionDepthComparator.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.networknt.exception;
+
+
+import org.wildfly.common.annotation.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Comparator capable of sorting exceptions based on their depth from the thrown exception type.
+ *
+ * @author Juergen Hoeller
+ * @author Arjen Poutsma
+ * @since 3.0.3
+ */
+public class ExceptionDepthComparator implements Comparator<Class<? extends Throwable>> {
+
+	private final Class<? extends Throwable> targetException;
+
+
+	/**
+	 * Create a new ExceptionDepthComparator for the given exception.
+	 * @param exception the target exception to compare to when sorting by depth
+	 */
+	public ExceptionDepthComparator(Throwable exception) {
+		if (exception==null) {
+			throw new IllegalArgumentException("Target exception must not be null");
+		}
+		this.targetException = exception.getClass();
+	}
+
+	/**
+	 * Create a new ExceptionDepthComparator for the given exception type.
+	 * @param exceptionType the target exception type to compare to when sorting by depth
+	 */
+	public ExceptionDepthComparator(Class<? extends Throwable> exceptionType) {
+		if (exceptionType==null) {
+			throw new IllegalArgumentException("Target exception type must not be null");
+		}
+		this.targetException = exceptionType;
+	}
+
+
+	@Override
+	public int compare(Class<? extends Throwable> o1, Class<? extends Throwable> o2) {
+		int depth1 = getDepth(o1, this.targetException, 0);
+		int depth2 = getDepth(o2, this.targetException, 0);
+		return (depth1 - depth2);
+	}
+
+	private int getDepth(Class<?> declaredException, Class<?> exceptionToMatch, int depth) {
+		if (exceptionToMatch.equals(declaredException)) {
+			// Found it!
+			return depth;
+		}
+		// If we've gone as far as we can go and haven't found it...
+		if (exceptionToMatch == Throwable.class) {
+			return Integer.MAX_VALUE;
+		}
+		return getDepth(declaredException, exceptionToMatch.getSuperclass(), depth + 1);
+	}
+
+
+	/**
+	 * Obtain the closest match from the given exception types for the given target exception.
+	 * @param exceptionTypes the collection of exception types
+	 * @param targetException the target exception to find a match for
+	 * @return the closest matching exception type from the given collection
+	 */
+	public static Class<? extends Throwable> findClosestMatch(
+			Collection<Class<? extends Throwable>> exceptionTypes, Throwable targetException) {
+
+		if (exceptionTypes.isEmpty()) {
+			throw new IllegalArgumentException("Exception types must not be empty");
+		}
+		if (exceptionTypes.size() == 1) {
+			return exceptionTypes.iterator().next();
+		}
+		List<Class<? extends Throwable>> handledExceptions = new ArrayList<>(exceptionTypes);
+		handledExceptions.sort(new ExceptionDepthComparator(targetException));
+		return handledExceptions.get(0);
+	}
+
+}

--- a/status/src/main/java/com/networknt/exception/ExceptionIndicator.java
+++ b/status/src/main/java/com/networknt/exception/ExceptionIndicator.java
@@ -1,0 +1,20 @@
+package com.networknt.exception;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for handling exceptions in specific processor classes and/or
+ * handler methods.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExceptionIndicator {
+
+    /**
+     * Exceptions handled by the annotated method.
+     */
+    Class<? extends Throwable>[] value() default {};
+}

--- a/status/src/test/java/com/networknt/exception/ExceptionProcessorTest.java
+++ b/status/src/test/java/com/networknt/exception/ExceptionProcessorTest.java
@@ -1,0 +1,59 @@
+package com.networknt.exception;
+
+import com.networknt.status.Status;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ExceptionProcessorTest {
+
+    static DefaultExceptionProcessor defaultExceptionProcessor;
+    static List<Class<? extends Throwable>> exceptions;
+
+    @BeforeClass
+    public static void setUp() throws  Exception{
+        defaultExceptionProcessor = new DefaultExceptionProcessor();
+        exceptions = new ArrayList<>();
+        processAnnotationMethods("com.networknt.exception.DefaultExceptionProcessor");
+    }
+
+    @Test
+    public void testApiException()  {
+        Status status = new Status("ERR11618");
+        ApiException apiException = new ApiException(status);
+        Status result = defaultExceptionProcessor.exception(apiException);
+        Assert.assertEquals("ERR11618", result.getCode());
+    }
+
+    @Test
+    public void testFrameworkException()  {
+        Status status = new Status("ERR13001");
+        FrameworkException fException = new FrameworkException(status);
+        Status result = defaultExceptionProcessor.exception(fException);
+        Assert.assertEquals("ERR13001", result.getCode());
+    }
+
+    @Test
+    public void testApiExceptionProcess()  {
+        Status status = new Status("ERR11618");
+        ApiException apiException = new ApiException(status);
+        Assert.assertTrue(exceptions.contains(apiException.getClass()));
+        Assert.assertFalse(exceptions.contains(new NullPointerException("null value").getClass()));
+    }
+
+    private static void processAnnotationMethods(String processorName) throws  Exception{
+        Class processor = Class.forName(processorName);
+        for (final Method method : processor.getDeclaredMethods()) {
+            if (method.isAnnotationPresent(ExceptionIndicator.class)) {
+                ExceptionIndicator annotInstance = method.getAnnotation(ExceptionIndicator.class);
+                exceptions.addAll(Arrays.stream(annotInstance.value()).collect(Collectors.toList()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
User can define centralized exception processor in the handler.yml (if not, system will use DefaultExceptionProcessor ):

for example:
exceptionProcessor: com.networknt.exception.DefaultExceptionProcessor 

sample exception handler method:

    @ExceptionIndicator(value = ExpiredTokenException.class)
    public Status exception(ExpiredTokenException exception) {
        Status status = new Status(TOKEN_EXPIRED);
        status.setMessage(exception.getMessage());
        return status;
    }