### PR TITLE
Revert "fixes #1183 add the Transfer-Encoding of http header into the client.yml"

### DIFF
--- a/client/src/main/java/com/networknt/client/ClientConfig.java
+++ b/client/src/main/java/com/networknt/client/ClientConfig.java
@@ -59,14 +59,12 @@ public final class ClientConfig {
     public static final long DEFAULT_CONNECTION_EXPIRE_TIME = 1000000;
     public static final int DEFAULT_MAX_CONNECTION_PER_HOST = 1000;
     public static final int DEFAULT_MIN_CONNECTION_PER_HOST = 250;
-    public static final String DEFAULT_TRANSFER_ENCODING = "chunked";
 
     private static final String CONNECTION_POOL_SIZE = "connectionPoolSize";
     private static final String MAX_REQUEST_PER_CONNECTION = "maxReqPerConn";
     private static final String CONNECTION_EXPIRE_TIME = "connectionExpireTime";
     private static final String MAX_CONNECTION_NUM_PER_HOST = "maxConnectionNumPerHost";
     private static final String MIN_CONNECTION_NUM_PER_HOST = "minConnectionNumPerHost";
-    private static final String TRANSFER_ENCODING = "transferEncoding";
 
     private final Config config;
     private final Map<String, Object> mappedConfig;
@@ -90,7 +88,6 @@ public final class ClientConfig {
     private long connectionExpireTime = DEFAULT_CONNECTION_EXPIRE_TIME;
     private int maxConnectionNumPerHost = DEFAULT_MAX_CONNECTION_PER_HOST;
     private int minConnectionNumPerHost = DEFAULT_MIN_CONNECTION_PER_HOST;
-    private String transferEncoding = DEFAULT_TRANSFER_ENCODING;
 
     private static ClientConfig instance;
 
@@ -189,9 +186,6 @@ public final class ClientConfig {
         }
         if (requestConfig.containsKey(MIN_CONNECTION_NUM_PER_HOST)) {
             minConnectionNumPerHost = (int) requestConfig.get(MIN_CONNECTION_NUM_PER_HOST);
-        }
-        if(requestConfig.containsKey(TRANSFER_ENCODING)) {
-            transferEncoding = (String)requestConfig.get(TRANSFER_ENCODING);
         }
     }
 
@@ -314,6 +308,4 @@ public final class ClientConfig {
     }
 
     public boolean isMultipleAuthServers() { return multipleAuthServers; }
-
-    public String getTransferEncoding() { return transferEncoding; }
 }

--- a/client/src/main/resources/config/client.yml
+++ b/client/src/main/resources/config/client.yml
@@ -216,5 +216,3 @@ request:
   # minimum quantity of connection in connection pool for each host. The corresponding connection number will shrink to minConnectionNumPerHost
   # by remove least recently used connections when the connection number of a host reach 0.75 * maxConnectionNumPerHost.
   minConnectionNumPerHost: ${client.minConnectionNumPerHost:250}
-  # Transfer-Encoding header. valid values: chucked, compress, deflate, gzip or or any valid combination of them. By default, the chucked is used.
-  transferEncoding: ${client.tansferEncoding:chucked}

--- a/client/src/test/resources/config/client-multiple.yml
+++ b/client/src/test/resources/config/client-multiple.yml
@@ -335,5 +335,3 @@ request:
   # minimum quantity of connection in connection pool for each host. The corresponding connection number will shrink to minConnectionNumPerHost
   # by remove least recently used connections when the connection number of a host reach 0.75 * maxConnectionNumPerHost.
   minConnectionNumPerHost: ${client.minConnectionNumPerHost:250}
-  # Transfer-Encoding header. valid values: chucked, compress, deflate, gzip or any valid combination of them. By default, the chucked is used.
-  transferEncoding: ${client.tansferEncoding:chucked}

--- a/client/src/test/resources/config/client-proxy.yml
+++ b/client/src/test/resources/config/client-proxy.yml
@@ -216,5 +216,3 @@ request:
   # minimum quantity of connection in connection pool for each host. The corresponding connection number will shrink to minConnectionNumPerHost
   # by remove least recently used connections when the connection number of a host reach 0.75 * maxConnectionNumPerHost.
   minConnectionNumPerHost: ${client.minConnectionNumPerHost:250}
-  # Transfer-Encoding header. valid values: chucked, compress, deflate, gzip or any valid combination of them. By default, the chucked is used.
-  transferEncoding: ${client.tansferEncoding:chucked}

--- a/client/src/test/resources/config/client-single.yml
+++ b/client/src/test/resources/config/client-single.yml
@@ -216,5 +216,3 @@ request:
   # minimum quantity of connection in connection pool for each host. The corresponding connection number will shrink to minConnectionNumPerHost
   # by remove least recently used connections when the connection number of a host reach 0.75 * maxConnectionNumPerHost.
   minConnectionNumPerHost: ${client.minConnectionNumPerHost:250}
-  # Transfer-Encoding header. valid values: chucked, compress, deflate, gzip or any valid combination of them. By default, the chucked is used.
-  transferEncoding: ${client.tansferEncoding:chucked}

--- a/client/src/test/resources/config/client.yml
+++ b/client/src/test/resources/config/client.yml
@@ -173,5 +173,3 @@ request:
   # minimum quantity of connection in connection pool for each host. The corresponding connection number will shrink to minConnectionNumPerHost
   # by remove least recently used connections when the connection number of a host reach 0.75 * maxConnectionNumPerHost.
   minConnectionNumPerHost: 250
-  # Transfer-Encoding header. valid values: chucked, compress, deflate, gzip or any valid combination of them. By default, the chucked is used.
-  transferEncoding: chucked


### PR DESCRIPTION
Reverts networknt/light-4j#1185

The other type of encodings is not supported. revert back.