### PR TITLE
Fix the potential risks of ExchangeCompleteListener

### DIFF
--- a/dump/src/main/java/com/networknt/dump/DumpHandler.java
+++ b/dump/src/main/java/com/networknt/dump/DumpHandler.java
@@ -84,10 +84,15 @@ public class DumpHandler implements MiddlewareHandler {
             }
             //when complete exchange, dump response info to result, and log the result.
             exchange.addExchangeCompleteListener((exchange1, nextListener) ->{
-                rootDumper.dumpResponse(result);
-                //log the result
-                DumpHelper.logResult(result, config);
-                nextListener.proceed();
+                try {
+                    rootDumper.dumpResponse(result);
+                    //log the result
+                    DumpHelper.logResult(result, config);
+                } catch (Throwable e) {
+                    logger.error("ExchangeListenerThrowable", e);
+                } finally {
+                    nextListener.proceed();
+                }
             });
         }
         Handler.next(exchange, next);


### PR DESCRIPTION
# The Problem Appearance

1. clone six repositories: light4j, light-rest-4j, light-hybrid-4j, light-codegen, json-overlay, openapi-parser.
2. compile them successfully.
3. genarate a project from my simple openapi specification. `java -jar codegen-cli/target/codegen-cli.jar -f openapi -o /tmp/xxx -m light-rest-4j/src/test/resources/a.yaml -c light-rest-4j/src/test/resources/aconfig.json`.
4. go to /tmp/xxx directory, I want to turn on the audit module to handle requestBody and responseBody, so i change `request` to `requestBody`, `response` to `responseBody` in src/main/resources/config/audit.yml.
5. execute command: `mvn clean package -Prelease`, i got a compile error, because a version property `version.fastscanner` is missed in pom.xml, so i add a line `<version.fastscanner>3.1.15</version.fastscanner>`. and try again with the same command, it works.(i have submitted [a pull request](https://github.com/networknt/light-codegen/pull/632) in light-codegen project)
6. go ahead, `docker build  -f docker/Dockerfile -t xxx:1.0 .` and `docker run -it --rm -p 8080:8080 xxx:1.0`.
7. then my server is started at port 8080.
8. open http://localhost:8080/specui.html in Chrome.
9. click `Try it out` and click `Execute`.
10. the response is returned correctly, but a error stacktrace writes to /log/test.log. the content is : `java.lang.NoClassDefFoundError: Could not initialize class com.jayway.jsonpath.internal.DefaultsImpl`.
11. then i click `Execute` again (don't refresh this page). the request is blocked. again and again, my server doesn't reponse to me no longer.
12. but when i refresh this page, then repeate above steps (9-11), the same problem occurs again. 

# Analysis

i found that the problem is jsonpath's classloading. because jsonpath's default implementation is SmartJSONProvider, but json-smart is excluded in light4j's pom.xml. so jsonpath can't be initialized correctly. there is a chance to fix this problem, i can uncomment two lines `# - com.networknt.server.StartupHookProvider:` and `# - com.networknt.server.JsonPathStartupHookProvider` in src/main/resources/config/service.xml (my generated xxx project). but this is not fact of this problem.

# The different between 1.6.42-SNAPSHOT and 2.1.2-SNAPSHOT

when i go through code snippets of audit module. i found that audit module use ExchangeCompleteListener to record statusCode and responseTime, but the audit for requestBody is controlled by statusCode and responseTime, so the action is invoked in reponse chain (not http reponse, but handler chain). i have checked out 2.1.2-SNAPSHOT branch, i found auditRequest has been move out from ExchangeCompleteListener.

in current branch (1.6.42-SNAPSHOT), the problem will arise and block requests when audit and mask parameter are both true in src/main/resources/config/audit.xml.

i compile branch 2.1.2-SNAPSHOT again，i found that the same exception stacktrace writes to  test.log in docker container. but my server (version: 2.1.2-SNAPSHOT) will not be blocked, i can click 'Execute' button again and again, i will get a error status code with 400.

# Dive into Undertown

i draw some diagrams to understand undertown's handler and exchange listener. 

i build a handler chain below with some exchange listeners.

![image](https://user-images.githubusercontent.com/58244032/185566194-30615757-b131-48b6-9bcc-7c3d768457c3.png)

then i visit my business handler with a path, some processes will happen in undertown's task thread and io thread.

![image](https://user-images.githubusercontent.com/58244032/185566934-0962d9d7-d7f2-4daa-99b8-269b572ae66f.png)

all exchange listeners will be executed in task thread, so the ExceptionHandler can catch NoClassDefoundError in 1.6.42-SNAPSHOT branch.

then i found some instructions in Undertown's official documentation.

> Once the current exchange is finished the exchange completion listeners will be run. The last completion listener will generally start processing the next request on the connection, and will have been setup by the read listener.

so i got something, in 1.6.42-SNAPSHOT branch, the mask action will be invoked in exchange completion listener, this action will throw a NoClassDefFoundError, and the listener chain was interupted by this error. Although the last ExceptionHanlder can catch this error with try...catch(Throwable)... , but the last completion listener **can't start processing the next request on the same connection**. but when i refresh this page http://localhost:8080/specui.html, i can execute one request, because this connection is a new http connection (it's up to Chrome's connection management mechanism).

but in 2.1.2-SNAPSHOT branch, auditRequest has been removed out from ExchangeCompleteListener, this error will not be caused in listener chain, so my server will not be blocked.

as i expected, i found some useful info in Undertown's Javadoc.

**Interface ExchangeCompletionListener**
> Listener interface for events that are run at the completion of a request/response cycle (i.e. when the request has been completely read, and the response has been fully written). At this point it is too late to modify the exchange further. Implementations are required invoke [ExchangeCompletionListener.NextListener.proceed()](https://undertow.io/javadoc/2.1.x/io/undertow/server/ExchangeCompletionListener.NextListener.html#proceed--) to allow other listeners to release resources, even in failure scenarios. This chain allows transfer of request ownership between listeners in order to complete using non-blocking mechanisms, and must not be used to conditionally proceed. Completion listeners are invoked in reverse order.

**Interface ExchangeCompletionListener.NextListener.proceed()**
> Invokes the next [listener](https://undertow.io/javadoc/2.1.x/io/undertow/server/ExchangeCompletionListener.html). This must be executed by every [ExchangeCompletionListener](https://undertow.io/javadoc/2.1.x/io/undertow/server/ExchangeCompletionListener.html) implementation, and may be invoked from a different thread as a callback. **Failure to proceed will cause resource leaks, and potentially cause requests to hang**.

# Summarize

so i think: as a best practice in exchange completion listener, all code snippets should be surrounded by try...catch(Throwable)...finally...，like this.

```
try {
    // some actions after exchange is complete
} catch (Throwable e) {
    logger.error("ExchangeListenerThrowable", e);
} finally {
    nextListener.proceed();
}
```