### PR TITLE
Changes made to the code as required. Mentioned in issue #1274 & #1287

### DIFF
--- a/config/src/main/java/com/networknt/config/Config.java
+++ b/config/src/main/java/com/networknt/config/Config.java
@@ -111,6 +111,8 @@ public abstract class Config {
         return FileConfigImpl.DEFAULT;
     }
 
+    public abstract String getDecryptorClassPublic();
+
     private static final class FileConfigImpl extends Config {
     	static final String CONFIG_NAME = "config";
         static final String CONFIG_EXT_JSON = ".json";
@@ -574,6 +576,8 @@ public abstract class Config {
             }
             return DecryptConstructor.DEFAULT_DECRYPTOR_CLASS;
         }
+
+        public String getDecryptorClassPublic() { return getDecryptorClass(); }
 
         private String getConfigLoaderClass() {
             Map<String, Object> config = loadModuleConfig();

--- a/config/src/main/java/com/networknt/config/ConfigInjection.java
+++ b/config/src/main/java/com/networknt/config/ConfigInjection.java
@@ -16,6 +16,9 @@
 
 package com.networknt.config;
 
+import com.networknt.config.yml.DecryptConstructor;
+import com.networknt.decrypt.Decryptor;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +59,37 @@ public class ConfigInjection {
 
     private static String[] trueArray = {"y", "Y", "yes", "Yes", "YES", "true", "True", "TRUE", "on", "On", "ON"};
     private static String[] falseArray = {"n", "N", "no", "No", "NO", "false", "False", "FALSE", "off", "Off", "OFF"};
+
+    static Decryptor getDecryptor() {
+        Config myConfig = Config.getInstance();
+        if (myConfig == null) {
+            throw new RuntimeException("Unable to retrieve the configuration.");
+        }
+        String decryptorClass = myConfig.getDecryptorClassPublic();
+        DecryptConstructor myDecryptCon = new DecryptConstructor(decryptorClass);
+        Decryptor myDecryptor = myDecryptCon.createDecryptorPublic(decryptorClass);
+
+        return myDecryptor;
+    }
+
+    static String convertEnvVars(String input){
+        // check for any non-alphanumeric chars and convert to underscore
+        // convert to uppcase
+        if (input == null) {
+            return null;
+        }
+        return input.replaceAll("[^A-Za-z0-9]", "_").toUpperCase();
+    }
+
+    static Object decryptEnvValue(Decryptor decryptor, String envVal) {
+        Object decryptedEnvValue;
+        //checking if the value put in env is encrypted. If yes then decrypting it.
+        if (envVal != null && envVal.trim().startsWith(Decryptor.CRYPT_PREFIX)) {
+            decryptedEnvValue = typeCast(decryptor.decrypt(envVal));
+        }else
+            decryptedEnvValue = envVal;
+        return decryptedEnvValue;
+    }
 
     // Method used to generate the values from environment variables or "values.yaml"
     public static Object getInjectValue(String string) {

--- a/config/src/main/java/com/networknt/config/ConfigInjection.java
+++ b/config/src/main/java/com/networknt/config/ConfigInjection.java
@@ -59,7 +59,7 @@ public class ConfigInjection {
 
     private static String[] trueArray = {"y", "Y", "yes", "Yes", "YES", "true", "True", "TRUE", "on", "On", "ON"};
     private static String[] falseArray = {"n", "N", "no", "No", "NO", "false", "False", "FALSE", "off", "Off", "OFF"};
-
+    private static Decryptor decryptor = getDecryptor();
 
     // Method used to generate the values from environment variables or "values.yaml"
     public static Object getInjectValue(String string) {
@@ -132,10 +132,7 @@ public class ConfigInjection {
             // Flag to validate whether the environment or values.yml contains the corresponding field
             Boolean containsField = false;
             // Use key of injectionPattern to get value from both environment variables and "values.yaml"
-
-
-            Decryptor decryptor = getDecryptor();
-            String envValString = (System.getenv(convertEnvVars(injectionPattern.getKey())));
+            String envValString = System.getenv(convertEnvVars(injectionPattern.getKey()));
             Object envValue = decryptEnvValue(decryptor, envValString);
 
             Map<String, Object> valueMap = Config.getInstance().getDefaultJsonMapConfig(CENTRALIZED_MANAGEMENT);

--- a/config/src/main/java/com/networknt/config/yml/DecryptConstructor.java
+++ b/config/src/main/java/com/networknt/config/yml/DecryptConstructor.java
@@ -56,6 +56,10 @@ public class DecryptConstructor extends Constructor {
 		
 		return null;
 	}
+
+	public Decryptor createDecryptorPublic(String decryptorClass) {
+		return createDecryptor(decryptorClass);
+	}
 	
     public class ConstructYamlDecryptedStr extends AbstractConstruct {
         @Override

--- a/config/src/test/java/com/networknt/config/ConfigInjectionTest.java
+++ b/config/src/test/java/com/networknt/config/ConfigInjectionTest.java
@@ -1,5 +1,7 @@
 package com.networknt.config;
 
+import com.networknt.decrypt.Decryptor;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -36,4 +38,68 @@ public class ConfigInjectionTest {
         assertNotNull(newConfigValue);
         assertEquals(configValue, newConfigValue);
     }
+
+    @Test
+    public void testConvertEnvVarsUsingDotInValue() {
+        String testInput = ConfigInjection.convertEnvVars("server.environment");
+        Assert.assertEquals("SERVER_ENVIRONMENT", testInput);
+    }
+
+    @Test
+    public void testConvertEnvVarsUsingDotInValueWithMixCases() {
+        String testInput = ConfigInjection.convertEnvVars("serVER.ENVironment");
+        Assert.assertEquals("SERVER_ENVIRONMENT", testInput);
+    }
+
+    @Test
+    public void testConvertEnvVarsUsingDotInValueWithCamelCasing() {
+        String testInput = ConfigInjection.convertEnvVars("server.ENVIRONMENT");
+        Assert.assertEquals("SERVER_ENVIRONMENT", testInput);
+    }
+
+
+    @Test
+    public void testConvertEnvVarsUsingNullValue() {
+        String testInput2 = ConfigInjection.convertEnvVars(null);
+        Assert.assertEquals(null, testInput2);
+    }
+
+    @Test
+    public void testConvertEnvVarsUsingEmptyString() {
+        String testInput3 = ConfigInjection.convertEnvVars("");
+        Assert.assertEquals("", testInput3);
+    }
+
+    @Test
+    public void testDecryptEnvValueWithEncryptedValue() {
+
+        Decryptor aesDecryptor = ConfigInjection.getDecryptor();
+        Object envValue = ConfigInjection.decryptEnvValue(aesDecryptor, "CRYPT:EqDVC30YKUDTMLXSIS5OpOqeP+K4w0dPaFfaJPfzIT8=");
+        Assert.assertEquals("password", envValue);
+    }
+
+    @Test
+    public void testDecryptEnvValueWithNonEncryptedValue() {
+
+        Decryptor aesDecryptor = ConfigInjection.getDecryptor();
+        Object envValue = ConfigInjection.decryptEnvValue(aesDecryptor, "password");
+        Assert.assertEquals("password", envValue);
+    }
+
+    @Test
+    public void testDecryptEnvValueWithEmptyValue() {
+
+        Decryptor aesDecryptor = ConfigInjection.getDecryptor();
+        Object envValue = ConfigInjection.decryptEnvValue(aesDecryptor, "");
+        Assert.assertEquals("", envValue);
+    }
+
+    @Test
+    public void testDecryptEnvValueWithNullValue() {
+
+        Decryptor aesDecryptor = ConfigInjection.getDecryptor();
+        Object envValue = ConfigInjection.decryptEnvValue(aesDecryptor, null);
+        Assert.assertEquals(null, envValue);
+    }
+
 }


### PR DESCRIPTION
Please review the code and let me know if there is anything else that I need to do before we merge it to the 1.6.x branch.

As mentioned in issue #1274 & #1287 and as discussed, with this new PR we give light-4j the capability of automatically converting the variable names to match the legal Environment variable format(Upper case and an underscore replacing the dot) at runtime. Also it will only do this conversion while it fetches the values from the Environment and would not affect the default variable naming convention that light-4j has as of now.

Also we are enhancing light-4j's capability to Decrypt encrypted values that are read from the environment.

NOTE: : Since We wanted to use the private method called getDecryptorClass() from the Config class, in our new method called getDecryptor() in the ConfigInjection class. We used it by creating a getDecryptorClassPublic() method in the Config class which returns the private getDecryptorClass() method and used it in the getDecryptor() method that we added in the ConfigInjection class.