### PR TITLE
Fix flaky test in URLNormalizerTest.java

### DIFF
--- a/http-url/src/test/java/com/networknt/url/URLNormalizerTest.java
+++ b/http-url/src/test/java/com/networknt/url/URLNormalizerTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class URLNormalizerTest {
 
@@ -66,7 +67,10 @@ public class URLNormalizerTest {
 //          System.out.println("toURI()   : " + n.toURI());
         assertEquals(t,  n.toString());
         assertEquals(t,  n.toURL().toString());
-        assertEquals(t,  n.toURI().toString());
+        String t1 = "http://example.org/1/~a_b:c%5Cd_%7Ce~f!g%20h/%5Ei%5EJ%5Bk%5D/l./"
+                        + "m/p/q/r/?dd=ee&bb=aa";
+        String res = n.toURI().toString();
+        assertTrue(res, t.equals(res) || t1.equals(res));
     }
 
     @Test


### PR DESCRIPTION
The test below in `URLNormalizerTest.java` was found flaky because of the ordering of result String. The orders of elements in the String are not the same every time being called. In this case, two possible outputs of the String are applied to ensure the orders do not cause the flakiness. This code change is trying to fix the [flaky tests](https://docs.gitlab.com/ee/development/testing_guide/flaky_tests.html) mentioned above, because they sometimes fail (as the picture showed) and sometimes pass. The failure could be reproduced by the commands above by using the tool of [NonDex](https://github.com/TestingResearchIllinois/NonDex). The code change is to make sure the tests will always pass in this case.

- `com.networknt.url.URLNormalizerTest.testAllAtOnce`

The test failures could be reproduced by

1. `mvn install -pl http-url -am -DskipTests`
2.  run tests with NonDex 
    `mvn -pl http-url edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.networknt.url.URLNormalizerTest#testAllAtOnce`


<img width="788" alt="3" src="https://user-images.githubusercontent.com/61256379/197282207-10f5dccb-0a5c-4828-ba43-e52223f2df1d.png">
