### PR TITLE
do not clear the local service registry cache when a consul connection fails

### DIFF
--- a/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
@@ -238,8 +238,7 @@ public class ConsulRegistry extends CommandFailbackRegistry {
                 logger.info("Consul returned no service updates: No need to update local Consul discovery cache for service {}, lastIndex={}", serviceName, lastConsulIndexId);
             }
         } else {
-            serviceUrls.put(serviceName, new ArrayList<>());
-            logger.info("No Consul response for service! Clearing local cache for service {}", serviceName);
+            logger.info("Consul UNRESPONSIVE - Service {}'s local Service Registry Cache potentially out of date", serviceName);
         }
         return serviceUrls;
     }


### PR DESCRIPTION
references issue https://github.com/networknt/light-4j/issues/1456