### PR TITLE
Consul connection creation can block forever and service cache erased if Consul connection fails

### DIFF
--- a/client/src/main/java/com/networknt/client/Http2Client.java
+++ b/client/src/main/java/com/networknt/client/Http2Client.java
@@ -188,7 +188,7 @@ public class Http2Client {
         try {
             connection = future.get();
         } catch (IOException e) {
-            throw new RuntimeException("Connection establishment timed out", e);
+            throw new RuntimeException("Connection establishment generated I/O exception", e);
         }
         return connection;
     }

--- a/client/src/main/java/com/networknt/client/http/Http2ClientConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/http/Http2ClientConnectionPool.java
@@ -65,6 +65,7 @@ public class Http2ClientConnectionPool {
         String uriString = uri.toString();
         List<CachedConnection> result = connectionPool.get(uriString);
         if (result == null) {
+            // TODO: Why is the entire class synchronized here?
             synchronized (Http2ClientConnectionPool.class) {
                 logger.info("Second try of getting connections for uri: {}", uriString);
                 result = connectionPool.get(uriString);

--- a/cluster/src/main/java/com/networknt/cluster/LightCluster.java
+++ b/cluster/src/main/java/com/networknt/cluster/LightCluster.java
@@ -56,12 +56,18 @@ public class LightCluster implements Cluster {
      * Implement serviceToUrl with client side service discovery.
      *
      * @param protocol either http or https
-     * @param serviceId unique service identifier
+     * @param serviceId unique service identifier - cannot be blank
      * @param requestKey String
      * @return Url discovered after the load balancing. Return null if the corresponding service cannot be found
      */
     @Override
-    public String serviceToUrl(String protocol, String serviceId, String tag, String requestKey) {
+    public String serviceToUrl(String protocol, String serviceId, String tag, String requestKey)
+    {
+        if(StringUtils.isBlank(serviceId)) {
+            logger.debug("The serviceId cannot be blank");
+            return null;
+        }
+
         URL url = loadBalance.select(discovery(protocol, serviceId, tag), requestKey);
         if (url != null) {
             logger.debug("Final url after load balance = {}.", url);
@@ -76,12 +82,18 @@ public class LightCluster implements Cluster {
     /**
      *
      * @param protocol either http or https
-     * @param serviceId unique service identifier
+     * @param serviceId unique service identifier - cannot be blank
      * @param tag an environment tag use along with serviceId for discovery
      * @return List of URI objects
      */
     @Override
-    public List<URI> services(String protocol, String serviceId, String tag) {
+    public List<URI> services(String protocol, String serviceId, String tag)
+    {
+        if(StringUtils.isBlank(serviceId)) {
+            logger.debug("The serviceId cannot be blank");
+            return new ArrayList<>();
+        }
+
         // transform to a list of URIs
         return discovery(protocol, serviceId, tag).stream()
                 .map(this::toUri)

--- a/consul/src/main/java/com/networknt/consul/ConsulConfig.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulConfig.java
@@ -28,6 +28,8 @@ public class ConsulConfig {
     boolean enableHttp2;
     String wait;
     String timeoutBuffer;
+    long connectionTimeout = 5;  // Consul connection timeout in seconds
+    long requestTimeout = 5;     // Consul request timeout in seconds (excluding /v1/health/service)
 
     public String getConsulUrl() {
         return consulUrl;
@@ -99,4 +101,8 @@ public class ConsulConfig {
     public void setEnableHttp2(boolean enableHttp2) {
         this.enableHttp2 = enableHttp2;
     }
+
+    public long getConnectionTimeout() { return connectionTimeout; }
+
+    public long getRequestTimeout() { return requestTimeout; }
 }

--- a/consul/src/main/java/com/networknt/consul/ConsulConfig.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulConfig.java
@@ -26,16 +26,17 @@ public class ConsulConfig {
     boolean httpCheck;
     boolean ttlCheck;
     boolean enableHttp2;
-    String wait;                            // length of blocking query with Consul
-    String timeoutBuffer;
+    String wait = "600s";                   // length of blocking query with Consul
+    String timeoutBuffer = "5s";            // An additional amount of time to wait for Consul to respond (to account for network latency)
     long connectionTimeout = 5;             // Consul connection timeout in seconds
     long requestTimeout = 5;                // Consul request timeout in seconds (excluding /v1/health/service)
     long reconnectInterval = 2;             // Time to wait in seconds between reconnect attempts when Consul connection fails
     long reconnectJitter = 2;               // Random seconds in [0..reconnectJitter) added to reconnectInterval
     long lookupInterval = 15;               // Time in seconds between blocking queries with Consul
-
     long maxAttemptsBeforeShutdown = -1;    // Max number of failed Consul reconnection attempts before self-termination
                                             // -1 means an infinite # of attempts
+    boolean shutdownIfThreadFrozen = false; // Shuts down host application if any Consul lookup thread stops reporting a
+                                            // heartbeat for 2 * ( lookupInterval + wait (s) + timeoutBuffer (s) ) seconds
 
     public String getConsulUrl() {
         return consulUrl;
@@ -119,4 +120,6 @@ public class ConsulConfig {
     public long getLookupInterval() { return lookupInterval; }
 
     public long getMaxAttemptsBeforeShutdown() { return maxAttemptsBeforeShutdown; }
+
+    public boolean isShutdownIfThreadFrozen() { return shutdownIfThreadFrozen; }
 }

--- a/consul/src/main/java/com/networknt/consul/ConsulConfig.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulConfig.java
@@ -26,13 +26,16 @@ public class ConsulConfig {
     boolean httpCheck;
     boolean ttlCheck;
     boolean enableHttp2;
-    String wait;                // length of blocking query with Consul
+    String wait;                            // length of blocking query with Consul
     String timeoutBuffer;
-    long connectionTimeout = 5; // Consul connection timeout in seconds
-    long requestTimeout = 5;    // Consul request timeout in seconds (excluding /v1/health/service)
-    long reconnectInterval = 2; // Time to wait in seconds between reconnect attempts when Consul connection fails
-    long reconnectJitter = 2;   // Random seconds in [0..reconnectJitter) added to reconnectInterval
-    long lookupInterval = 15;   // Time in seconds between blocking queries with Consul
+    long connectionTimeout = 5;             // Consul connection timeout in seconds
+    long requestTimeout = 5;                // Consul request timeout in seconds (excluding /v1/health/service)
+    long reconnectInterval = 2;             // Time to wait in seconds between reconnect attempts when Consul connection fails
+    long reconnectJitter = 2;               // Random seconds in [0..reconnectJitter) added to reconnectInterval
+    long lookupInterval = 15;               // Time in seconds between blocking queries with Consul
+
+    long maxAttemptsBeforeShutdown = -1;    // Max number of failed Consul reconnection attempts before self-termination
+                                            // -1 means an infinite # of attempts
 
     public String getConsulUrl() {
         return consulUrl;
@@ -114,4 +117,6 @@ public class ConsulConfig {
     public long getReconnectJitter() { return reconnectJitter; }
 
     public long getLookupInterval() { return lookupInterval; }
+
+    public long getMaxAttemptsBeforeShutdown() { return maxAttemptsBeforeShutdown; }
 }

--- a/consul/src/main/java/com/networknt/consul/ConsulConfig.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulConfig.java
@@ -26,10 +26,13 @@ public class ConsulConfig {
     boolean httpCheck;
     boolean ttlCheck;
     boolean enableHttp2;
-    String wait;
+    String wait;                // length of blocking query with Consul
     String timeoutBuffer;
-    long connectionTimeout = 5;  // Consul connection timeout in seconds
-    long requestTimeout = 5;     // Consul request timeout in seconds (excluding /v1/health/service)
+    long connectionTimeout = 5; // Consul connection timeout in seconds
+    long requestTimeout = 5;    // Consul request timeout in seconds (excluding /v1/health/service)
+    long reconnectInterval = 2; // Time to wait in seconds between reconnect attempts when Consul connection fails
+    long reconnectJitter = 2;   // Random seconds in [0..reconnectJitter) added to reconnectInterval
+    long lookupInterval = 15;   // Time in seconds between blocking queries with Consul
 
     public String getConsulUrl() {
         return consulUrl;
@@ -105,4 +108,10 @@ public class ConsulConfig {
     public long getConnectionTimeout() { return connectionTimeout; }
 
     public long getRequestTimeout() { return requestTimeout; }
+
+    public long getReconnectInterval() { return reconnectInterval; }
+
+    public long getReconnectJitter() { return reconnectJitter; }
+
+    public long getLookupInterval() { return lookupInterval; }
 }

--- a/consul/src/main/java/com/networknt/consul/ConsulRecoveryManager.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulRecoveryManager.java
@@ -1,0 +1,62 @@
+package com.networknt.consul;
+
+import com.networknt.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ConsulRecoveryManager
+{
+    private static final Logger logger = LoggerFactory.getLogger(ConsulRecoveryManager.class);
+    private static final ConsulConfig config =
+            (ConsulConfig) Config.getInstance().getJsonObjectConfig(ConsulConstants.CONFIG_NAME, ConsulConfig.class);
+    private static final AtomicBoolean shutdown = new AtomicBoolean(false);
+
+    private boolean isRecoveryMode;
+    private long recoveryAttempts = 0;
+    private String serviceName;
+
+    public ConsulRecoveryManager(String serviceName) { this.serviceName = serviceName; }
+
+    /**
+     * Exit Consul connection recovery mode
+     *
+     * @return the previous recovery mode state
+     */
+    public boolean exitRecoveryMode() {
+        recoveryAttempts = 0;
+        boolean oldMode = isRecoveryMode;
+        isRecoveryMode = false;
+        return oldMode;
+    }
+
+    /**
+     * Record a new failed attempt to recover the Consul connection
+     *
+     * @return true if additional failed attempts are permitted
+     *         false if this new failed attempt was the last permitted attempt
+     */
+    public boolean newFailedAttempt() {
+        isRecoveryMode = true;
+        ++recoveryAttempts;
+        logger.error("Recovery mode: Fixing Consul Connection for service {} - attempt {}...", serviceName, recoveryAttempts);
+        if(config.getMaxAttemptsBeforeShutdown() == -1) return true;
+        return config.getMaxAttemptsBeforeShutdown() >= recoveryAttempts;
+    }
+
+    /**
+     * Gracefully shuts down the host application
+     */
+    public static synchronized void gracefulShutdown() {
+        if(shutdown.get()) return;
+        logger.error("System shutdown initiated - Consul connection could not be reestablished");
+        shutdown.set(true);
+        System.exit(1);
+    }
+
+    public boolean isRecoveryMode() { return isRecoveryMode; }
+    public long getRecoveryAttempts() { return recoveryAttempts; }
+    public String getServiceName() { return serviceName; }
+    public void setServiceName(String serviceName) { this.serviceName = serviceName; }
+}

--- a/consul/src/main/java/com/networknt/consul/ConsulRecoveryManager.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulRecoveryManager.java
@@ -3,21 +3,34 @@ package com.networknt.consul;
 import com.networknt.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class ConsulRecoveryManager
-{
+public class ConsulRecoveryManager {
     private static final Logger logger = LoggerFactory.getLogger(ConsulRecoveryManager.class);
     private static final ConsulConfig config =
             (ConsulConfig) Config.getInstance().getJsonObjectConfig(ConsulConstants.CONFIG_NAME, ConsulConfig.class);
     private static final AtomicBoolean shutdown = new AtomicBoolean(false);
 
+    private static final AtomicBoolean monitorThreadStarted = new AtomicBoolean(false);
+    private static final ConcurrentHashMap<String,Long> heartbeats = new ConcurrentHashMap<>();
+    private static final ConsulThreadMonitor consulThreadMonitor = new ConsulThreadMonitor(heartbeats);
+
     private boolean isRecoveryMode;
     private long recoveryAttempts = 0;
     private String serviceName;
 
-    public ConsulRecoveryManager(String serviceName) { this.serviceName = serviceName; }
+    public ConsulRecoveryManager(String serviceName) {
+        this.serviceName = serviceName;
+        startConsulThreadMonitor();
+    }
+
+    private static synchronized void startConsulThreadMonitor() {
+        if(monitorThreadStarted.get()) return;
+        monitorThreadStarted.set(true);
+        logger.debug("Starting Consul Thread Monitor...");
+        consulThreadMonitor.start();
+    }
 
     /**
      * Exit Consul connection recovery mode
@@ -53,6 +66,11 @@ public class ConsulRecoveryManager
         logger.error("System shutdown initiated - Consul connection could not be reestablished");
         shutdown.set(true);
         System.exit(1);
+    }
+
+    public void checkin() {
+        logger.debug("Service {} checking in", serviceName);
+        heartbeats.put(serviceName, System.currentTimeMillis());
     }
 
     public boolean isRecoveryMode() { return isRecoveryMode; }

--- a/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
@@ -440,9 +440,9 @@ public class ConsulRegistry extends CommandFailbackRegistry {
 
                         while(serviceUrls == null)
                         {
+                            logger.error("CONSUL CONNECTION RECOVERY MODE ENABLED for {}", serviceName);
                             long randomJitter = ThreadLocalRandom.current().nextLong(0, reconnectJitter);
                             Thread.sleep(reconnectInterval + randomJitter);
-                            logger.error("CONSUL CONNECTION RECOVERY MODE ENABLED for {}", serviceName);
                             serviceUrls = lookupServiceUpdate(protocol, serviceName);
                         }
 

--- a/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
@@ -27,6 +27,7 @@ import com.networknt.registry.support.command.CommandFailbackRegistry;
 import com.networknt.registry.support.command.CommandServiceManager;
 import com.networknt.registry.support.command.ServiceListener;
 import com.networknt.utility.Constants;
+import com.networknt.utility.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,9 +136,14 @@ public class ConsulRegistry extends CommandFailbackRegistry {
      *
      * @param url
      */
-    private void startListenerThreadIfNewService(URL url) {
-        // TODO: Do NOT start a listener thread if serviceName is blank
+    private void startListenerThreadIfNewService(URL url)
+    {
         String serviceName = url.getPath();
+
+        // Do NOT start a listener thread if serviceName is blank
+        if(StringUtils.isBlank(serviceName))
+            return;
+
         String protocol = url.getProtocol();
         if (!lookupServices.containsKey(serviceName)) {
             Long value = lookupServices.putIfAbsent(serviceName, 0L);

--- a/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
@@ -261,8 +261,7 @@ public class ConsulRegistry extends CommandFailbackRegistry {
                 logger.info("Consul returned no service updates: No need to update local Consul discovery cache for service {}, lastIndex={}", serviceName, lastConsulIndexId);
             }
         } else {
-            serviceUrls.put(serviceName, new ArrayList<>());
-            logger.info("Clearing local cache for service {}", serviceName);
+            logger.info("Connection to Consul failed for service {} - Local service cache may be out of date", serviceName);
         }
 
         return serviceUrls;

--- a/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
@@ -447,13 +447,15 @@ public class ConsulRegistry extends CommandFailbackRegistry {
             this.serviceName = serviceName;
         }
 
-        // TODO: The MAIN CONSUL LOOP
         @Override
         public void run() {
             ConsulRecoveryManager consulRecovery = new ConsulRecoveryManager(serviceName);
 
             logger.info("Start Consul lookupServiceUpdate thread - Lookup interval: {}ms, service {}", lookupInterval, serviceName);
             while (true) {
+                // check in with the recovery manager
+                consulRecovery.checkin();
+
                 try {
                     logger.info("Consul lookupServiceUpdate Thread - SLEEP: Start to sleep {}ms for service {}", lookupInterval, serviceName);
                     sleep(lookupInterval);
@@ -466,6 +468,9 @@ public class ConsulRegistry extends CommandFailbackRegistry {
                     {
                         while(serviceUrls == null)
                         {
+                            // check in with the recovery manager
+                            consulRecovery.checkin();
+
                             // if max connection reattempts have been reached, shut down the host application
                             boolean moreAttemptsPermitted = consulRecovery.newFailedAttempt();
                             if(!moreAttemptsPermitted)

--- a/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
@@ -409,11 +409,7 @@ public class ConsulRegistry extends CommandFailbackRegistry {
                         logger.debug("Got service URLs from Consul lookupServiceUpdate: {} service URLs found for service {} ({})",
                                 serviceUrls.getOrDefault(serviceName, Collections.emptyList()).size(), serviceName, protocol);
 
-                    // TODO: DO NOT update local service cache if serviceUrls == null
-                    // TODO: BUT *DO* update local service cache if serviceUrls != null (even if empty list)
                     updateServiceCache(serviceName, serviceUrls, true);
-
-                    logger.info("Local Consul service cache updated with service URLs from lookupServiceUpdate for {}", serviceName);
 
                 } catch (Throwable e) {
                     logger.error("Consul lookupServiceUpdate thread failed!", e);

--- a/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
@@ -403,7 +403,12 @@ public class ConsulRegistry extends CommandFailbackRegistry {
                     logger.info("Consul lookupServiceUpdate Thread - WAKE UP: Woke up from sleep for lookupServiceUpdate for service {}", serviceName);
                     ConcurrentHashMap<String, List<URL>> serviceUrls = lookupServiceUpdate(protocol, serviceName);
 
-                    logger.info("Got service URLs from Consul lookupServiceUpdate: {} service URLs found for service {} ({})", serviceUrls.getOrDefault(serviceName, Collections.emptyList()).size(), serviceName, protocol);
+                    if(serviceUrls == null || serviceUrls.size() == 0)
+                        logger.debug("No service URL updates from Consul lookupServiceUpdate for service {}", serviceName);
+                    else
+                        logger.debug("Got service URLs from Consul lookupServiceUpdate: {} service URLs found for service {} ({})",
+                                serviceUrls.getOrDefault(serviceName, Collections.emptyList()).size(), serviceName, protocol);
+
                     // TODO: DO NOT update local service cache if serviceUrls == null
                     // TODO: BUT *DO* update local service cache if serviceUrls != null (even if empty list)
                     updateServiceCache(serviceName, serviceUrls, true);

--- a/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
@@ -238,7 +238,8 @@ public class ConsulRegistry extends CommandFailbackRegistry {
                 logger.info("Consul returned no service updates: No need to update local Consul discovery cache for service {}, lastIndex={}", serviceName, lastConsulIndexId);
             }
         } else {
-            logger.info("Consul UNRESPONSIVE - Service {}'s local Service Registry Cache potentially out of date", serviceName);
+            serviceUrls.put(serviceName, new ArrayList<>());
+            logger.info("Clearing local cache for service {}", serviceName);
         }
         return serviceUrls;
     }

--- a/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulRegistry.java
@@ -257,11 +257,15 @@ public class ConsulRegistry extends CommandFailbackRegistry {
      *         then:
      *           - serviceUrls == null
      *
+     *           This result indicates to updateServiceCache() to leave local registry cache unchanged
+     *
      *         if:
      *           - Consul index was stale, or
      *           - Consul reported no updates since last query
      *         then:
      *           - serviceUrls.size() == 0 (e.g.: Map has no k/v pairs)
+     *
+     *           This result indicates to updateServiceCache() to leave local registry cache unchanged
      *
      *         if:
      *           - the IP set registered for serviceName has changed
@@ -269,6 +273,9 @@ public class ConsulRegistry extends CommandFailbackRegistry {
      *           - serviceUrls.size() > 0, and
      *           - serviceUrls.get(serviceName) != null, and
      *           - serviceUrls.get(serviceName).size() == number of IPs registered for serviceName in Consul
+     *
+     *           This result indicates to updateServiceCache() to update local registry cache
+     *
      */
     private ConcurrentHashMap<String, List<URL>> lookupServiceUpdate(String protocol, String serviceName, boolean isBlockQuery)
     {

--- a/consul/src/main/java/com/networknt/consul/ConsulThreadMonitor.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulThreadMonitor.java
@@ -31,7 +31,7 @@ public class ConsulThreadMonitor extends Thread {
                 for(Map.Entry<String,Long> beat : heartbeats.entrySet()) {
                     if(now - beat.getValue().longValue() > MAX_TIME_BETWEEN_BEATS_MS) {
                         if(shutdownIfThreadFrozen) {
-                            logger.error("Service {} has missed its check in... Restarting host", beat.getKey());
+                            logger.error("Service {} has missed its check in... Shutting down host...", beat.getKey());
                             ConsulRecoveryManager.gracefulShutdown();
                         } else
                             logger.error("Service {} has missed its check in - Please restart host", beat.getKey());

--- a/consul/src/main/java/com/networknt/consul/ConsulThreadMonitor.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulThreadMonitor.java
@@ -1,2 +1,45 @@
-package com.networknt.consul;public class ConsulThreadMonitor {
+package com.networknt.consul;
+
+import com.networknt.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ConsulThreadMonitor extends Thread {
+    private static final Logger logger = LoggerFactory.getLogger(ConsulThreadMonitor.class);
+    private static final ConsulConfig config =
+            (ConsulConfig) Config.getInstance().getJsonObjectConfig(ConsulConstants.CONFIG_NAME, ConsulConfig.class);
+    private final ConcurrentHashMap<String,Long> heartbeats;
+
+    private boolean shutdownIfThreadFrozen = config.isShutdownIfThreadFrozen();
+    private static final long WAIT_S = ConsulUtils.getWaitInSecond(config.getWait());
+    private static final long TIMEOUT_BUFFER_S = ConsulUtils.getTimeoutBufferInSecond(config.getTimeoutBuffer());
+    private static final long LOOKUP_INTERVAL_S = config.getLookupInterval();
+    private static final long MAX_TIME_BETWEEN_BEATS_MS = 2 * 1000 * ( LOOKUP_INTERVAL_S + WAIT_S + TIMEOUT_BUFFER_S );
+
+    public ConsulThreadMonitor(final ConcurrentHashMap<String,Long> heartbeats) {
+        this.heartbeats = heartbeats;
+    }
+
+    public void run() {
+        long now;
+        while(true) {
+            try {
+                Thread.sleep(MAX_TIME_BETWEEN_BEATS_MS);
+                now = System.currentTimeMillis();
+                for(Map.Entry<String,Long> beat : heartbeats.entrySet()) {
+                    if(now - beat.getValue().longValue() > MAX_TIME_BETWEEN_BEATS_MS) {
+                        if(shutdownIfThreadFrozen) {
+                            logger.error("Service {} has missed its check in... Restarting host", beat.getKey());
+                            ConsulRecoveryManager.gracefulShutdown();
+                        } else
+                            logger.error("Service {} has missed its check in - Please restart host", beat.getKey());
+                    } else
+                        logger.debug("Service {} checked in on time", beat.getKey());
+                }
+            } catch (InterruptedException i) { logger.error("Consul Monitor Thread Interrupted", i);
+            } catch (Exception e) { logger.error("Consul Monitor Thread Exception", e); }
+        }
+    }
 }

--- a/consul/src/main/java/com/networknt/consul/ConsulThreadMonitor.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulThreadMonitor.java
@@ -1,0 +1,2 @@
+package com.networknt.consul;public class ConsulThreadMonitor {
+}

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClient.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClient.java
@@ -58,11 +58,20 @@ public interface ConsulClient {
 	/**
 	 * get latest service list with a tag filter and a security token
 	 *
-	 * @param serviceName service name
+	 * to lookup health services based on serviceName,
+	 * if lastConsulIndex == 0, will get result right away.
+	 * if lastConsulIndex != 0, will establish a long query with consul with {@link #wait} seconds.
+	 *
+	 * @param serviceName service name (service_id)
+	 * @param tag tag that is used for filtering (env_tag)
 	 * @param lastConsulIndex last consul index
-	 * @param tag tag that is used for filtering
-	 * @param token consul token for security
-	 * @return T
+	 * @param token Consul token for security (Consul ACL)
+	 * @return	if Consul connection fails:
+	 * 				- newResponse is null
+	 * 			if Consul connection successful:
+	 * 				- newResponse is non-null, and
+	 *         		- newResponse.getValue() != null, and
+	 *				- newResponse.getValue().size() == number of IPs registered for serviceName in Consul
 	 */
 	ConsulResponse<List<ConsulService>> lookupHealthService(String serviceName, String tag, long lastConsulIndex, String token);
 

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClient.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClient.java
@@ -60,7 +60,7 @@ public interface ConsulClient {
 	 *
 	 * to lookup health services based on serviceName,
 	 * if lastConsulIndex == 0, will get result right away.
-	 * if lastConsulIndex != 0, will establish a long query with consul with {@link #wait} seconds.
+	 * if lastConsulIndex != 0, will establish a long query with Consul.
 	 *
 	 * @param serviceName service name (service_id)
 	 * @param tag tag that is used for filtering (env_tag)

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
@@ -212,9 +212,9 @@ public class ConsulClientImpl implements ConsulClient {
 
 			// Check that reference.get() is not null
 			if(reference.get() == null)
-				throw new ConsulRequestException("REQUEST TO CONSUL FAILED - Received null response");
+				throw new ConsulRequestException("Request to Consul failed - null response returned from Consul");
 
-			logger.debug("CONSUL REQUEST WAS SUCCESSFUL");
+			logger.debug("Consul connection is OK for service {}", serviceName);
 
 			int statusCode = reference.get().getResponseCode();
 			logger.info("Got Consul Query status code: {}", statusCode);
@@ -269,7 +269,7 @@ public class ConsulClientImpl implements ConsulClient {
 			// This should only return null if Consul connection fails
 			logger.error("Exception:", e);
 
-			logger.error("Consul connection or request failed - Terminating connection to Consul");
+			logger.error("Consul connection or request failed - Terminating and retrying connection to Consul...");
 			if(connection != null && connection.isOpen()) IoUtils.safeClose(connection);
 			return null;
 

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
@@ -256,6 +256,15 @@ public class ConsulClientImpl implements ConsulClient {
 				IoUtils.safeClose(connection);
 			return null;
 
+		} catch (InterruptedException e) {
+			// Issue occurred while waiting for await/timeout thread to complete
+			logger.error("Exception:", e);
+
+			logger.debug("Consul connection timeout thread interrupted - Terminating connection to Consul");
+			if(connection != null && connection.isOpen())
+				IoUtils.safeClose(connection);
+			return null;
+			
 		} catch(Exception e) {
 			// This should only return null if Consul connection fails
 			logger.error("Exception:", e);

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
@@ -86,7 +86,9 @@ public class ConsulClientImpl implements ConsulClient {
 		String path = "/v1/agent/check/pass/" + "check-" + serviceId;
 		ClientConnection connection = null;
 		try {
-			connection = client.borrowConnection(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap).get();
+			connection = client.safeBorrowConnection(
+					config.getConnectionTimeout(), uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap);
+
 			AtomicReference<ClientResponse> reference = send(connection, Methods.PUT, path, token, null);
 			int statusCode = reference.get().getResponseCode();
 			if(statusCode >= UNUSUAL_STATUS_CODE){
@@ -106,7 +108,9 @@ public class ConsulClientImpl implements ConsulClient {
 		String path = "/v1/agent/check/fail/" + "check-" + serviceId;
 		ClientConnection connection = null;
 		try {
-			connection = client.borrowConnection(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap).get();
+			connection = client.safeBorrowConnection(
+					config.getConnectionTimeout(), uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap);
+
 			AtomicReference<ClientResponse> reference = send(connection, Methods.PUT, path, token, null);
 			int statusCode = reference.get().getResponseCode();
 			if(statusCode >= UNUSUAL_STATUS_CODE){
@@ -125,7 +129,9 @@ public class ConsulClientImpl implements ConsulClient {
 		String path = "/v1/agent/service/register";
 		ClientConnection connection = null;
 		try {
-			connection = client.borrowConnection(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap).get();
+			connection = client.safeBorrowConnection(
+					config.getConnectionTimeout(), uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap);
+
 			AtomicReference<ClientResponse> reference = send(connection, Methods.PUT, path, token, json);
 			int statusCode = reference.get().getResponseCode();
 			if(statusCode >= UNUSUAL_STATUS_CODE){
@@ -144,7 +150,9 @@ public class ConsulClientImpl implements ConsulClient {
 		String path = "/v1/agent/service/deregister/" + serviceId;
 		ClientConnection connection = null;
 		try {
-			connection = client.borrowConnection(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap).get();
+			connection = client.safeBorrowConnection(
+					config.getConnectionTimeout(), uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap);
+
 	        final AtomicReference<ClientResponse> reference = send(connection, Methods.PUT, path, token, null);
             int statusCode = reference.get().getResponseCode();
             if(statusCode >= UNUSUAL_STATUS_CODE){
@@ -183,7 +191,9 @@ public class ConsulClientImpl implements ConsulClient {
 		logger.trace("Consul health service path = {}", path);
 		try {
 			logger.debug("Getting connection from pool with {}", uri);
-			connection = client.borrowConnection(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap).get();
+			connection = client.safeBorrowConnection(
+					config.getConnectionTimeout(), uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap);
+
 			logger.info("Got connection: {} from pool and send request to {}", connection, path);
 			AtomicReference<ClientResponse> reference  = send(connection, Methods.GET, path, token, null);
 			int statusCode = reference.get().getResponseCode();

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
@@ -207,7 +207,7 @@ public class ConsulClientImpl implements ConsulClient {
 
 			// Check that reference.get() is not null
 			if(reference.get() == null)
-				throw new RuntimeException("Connection to Consul failed - Received null response");
+				throw new ConsulConnectionException("Connection to Consul failed - Received null response");
 
 			int statusCode = reference.get().getResponseCode();
 			logger.info("Got Consul Query status code: {}", statusCode);
@@ -228,7 +228,8 @@ public class ConsulClientImpl implements ConsulClient {
 					consulServices.add(newService);
 				}
 
-				// TODO: !isEmpty() causes this method to return null on a successful Consul request, if no IPs registered
+				// Previously, consulServices.isEmpty()==true causes this method to return null on a successful Consul
+				// request, when no IPs are returned
 				//if (!consulServices.isEmpty()) {
 				newResponse = new ConsulResponse<>();
 				newResponse.setValue(consulServices);
@@ -247,6 +248,7 @@ public class ConsulClientImpl implements ConsulClient {
 			return null;
 
 		} catch(Exception e) {
+			// This should only return null if Consul connection fails
 			logger.error("Exception:", e);
 			return null;
 

--- a/consul/src/main/resources/config/consul.yml
+++ b/consul/src/main/resources/config/consul.yml
@@ -41,7 +41,10 @@ reconnectInterval: 2
 # requests at one time)
 reconnectJitter: 2
 # Time in seconds between blocking queries with Consul
-lookupInterval: 15
+lookupInterval: 30
 # Max number of failed Consul connection or request attempts before self-termination
 # -1 means an infinite # of attempts are allowed
 maxAttemptsBeforeShutdown: -1
+# Shuts down host application if any Consul lookup thread stops reporting a heartbeat for
+# 2 * ( lookupInterval + wait (in seconds) + timeoutBuffer (in seconds) ) seconds
+shutdownIfThreadFrozen: false

--- a/consul/src/main/resources/config/consul.yml
+++ b/consul/src/main/resources/config/consul.yml
@@ -30,3 +30,15 @@ timeoutBuffer: 5s
 # must disable when using HTTP with Consul (mostly using local Consul agent), Consul only supports HTTP/1.1 when not using TLS
 # optional to enable when using HTTPS with Consul, it will have better performance
 enableHttp2: false
+# Consul connection establishment timeout in seconds
+connectionTimeout: 5
+# Consul request completion timeout in seconds (excluding /v1/health/service)
+requestTimeout: 5
+# Time to wait in seconds between reconnect attempts when Consul connection fails
+reconnectInterval: 2
+# A random number of seconds in between 0 and reconnectJitter added to reconnectInterval (to avoid too many reconnect
+# requests at one time)
+reconnectJitter: 2
+# Time in seconds between blocking queries with Consul
+lookupInterval: 15
+

--- a/consul/src/main/resources/config/consul.yml
+++ b/consul/src/main/resources/config/consul.yml
@@ -32,7 +32,8 @@ timeoutBuffer: 5s
 enableHttp2: false
 # Consul connection establishment timeout in seconds
 connectionTimeout: 5
-# Consul request completion timeout in seconds (excluding /v1/health/service)
+# Consul request completion timeout in seconds
+# This does NOT apply to Consul service discovery lookups (see the 'wait' and 'timeoutBuffer' properties for that)
 requestTimeout: 5
 # Time to wait in seconds between reconnect attempts when Consul connection fails
 reconnectInterval: 2
@@ -41,4 +42,6 @@ reconnectInterval: 2
 reconnectJitter: 2
 # Time in seconds between blocking queries with Consul
 lookupInterval: 15
-
+# Max number of failed Consul connection or request attempts before self-termination
+# -1 means an infinite # of attempts are allowed
+maxAttemptsBeforeShutdown: -1


### PR DESCRIPTION
This PR references Issue 1503 (https://github.com/networknt/light-4j/issues/1503).

This PR aims to address these issues in a comprehensive but minimally disruptive
manner.

# Issue 1
- **Consul service discovery can block forever trying to create a connection to Consul**

### CODE CHANGE #1
Add new property `connectionTimeout` (default 5s) to `ConsulConfig` for use in consul.yml.

### CODE CHANGE #2
In the existing code, connections were borrowed from Http2ConnectionPool as follows:

```java
connection = client.borrowConnection(uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap).get();
```

However, `borrowConnection()` returns a future (`IoFuture<ClientConnection>`), meaning that the `get()` can block forever in some cases.

To fix this, add a new method to Http2ConnectionPool called `safeBorrowConnection()` that returns the ClientConnection after checking for a timeout (timeout length defined by `connectionTimeout` in consul.yml).

```java
// this will throw a Runtime Exception if creation of Consul connection fails
connection = client.safeBorrowConnection(
    config.getConnectionTimeout(), uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap);
```

### CODE CHANGE #3
Added a new class `ConsulRecoveryManager` that keeps track of the state of the connection to Consul, and provides methods to gracefully shutdown the host application.

Added a new `consul.yml` property `maxAttemptsBeforeShutdown` that will allow a fixed number of Consul connection/request failures before shutting down the host system. A value of `-1` will permit an infinite number of failed attempts.

### CODE CHANGE #4
Added a new thread `ConsulThreadMonitor` to monitor the Consul Service Lookup threads (`ConsulRegistry.ServiceLookupThread`) to ensure that they are not blocking. The `ConsulThreadMonitor` thread is spawned by the `ConsulRecoveryManager`.

`ServiceLookupThread` threads now "check in" at least once per loop. `ConsulThreadMonitor` will check to see that all `ServiceLookupThread`s have checked in at least once every 2 * (`lookupInterval` + `wait` + `timeoutBuffer`) seconds. If any thread does not check in on time, and if the new `consul.yml` boolean property `shutdownIfThreadFrozen` is `true`, then ConsulThreadMonitor will shut down the host application.

# Issues 2 and 3
- **Consul service discovery treats an empty response from Consul as a successful connection**, and
- **Consul service discovery does not preserve its local service cache during temporary loss of connection to Consul**

In the current code, `ConsulClientImpl.lookupHealthService()` treats the following two conditions as the same:

  1) The connection to Consul failed
  2) A successful response from Consul returned 0 IPs for a service

**NOTE**: An 'empty' response means no payload at all (like `null`)... If consul returns an empty JSON list (e.g.: "`[]`"), this is NOT considered an empty response.

### CODE CHANGE #1: ConsulClientImpl.lookupHealthService()

Update ConsulResponse<List<ConsulService>> ConsulClientImpl.lookupHealthService() to behave as follows:

If `ConsulResponse<List<ConsulService>> newResponse = ConsulRegistry.lookupHealthService(..)`, then:

 - IF Consul connection fails:
   - newResponse is null

  - IF Consul connection successful:
    - newResponse is non-null, and
    - newResponse.getValue() != null, and
    - newResponse.getValue().size() == number of IPs registered for serviceName in Consul

### CODE CHANGE #2 (UPDATED Dec 10, 2022):

Update ConsulRegistry.lookupServiceUpdate() so that if
    
`ConcurrentHashMap<String, List<URL>> serviceUrls = ConsulRegistry.lookupServiceUpdate(..)`,
then...

  - IF:
    - **There is a Consul connection issue**
  - then:
    - serviceUrls == null

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*This result indicates to updateServiceCache() to leave local registry cache unchanged*

  - IF:
    - **Consul index was stale, or**
    - **Consul reported no updates since last query**
  - then:
    - serviceUrls.size() == 0 (e.g.: Map has no k/v pairs)

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*This result indicates to updateServiceCache() to leave local registry cache unchanged*

  - IF:
    - **the IP set registered for serviceName has changed**
  - then:
    - serviceUrls.size() > 0, and
    - serviceUrls.get(serviceName) != null, and
    - serviceUrls.get(serviceName).size() == number of IPs registered for serviceName in Consul

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*This result indicates to updateServiceCache() to update local registry cache*
