### PR TITLE
remove obvious comment

### DIFF
--- a/server/src/main/java/com/networknt/server/UrlConfigLoader.java
+++ b/server/src/main/java/com/networknt/server/UrlConfigLoader.java
@@ -279,7 +279,6 @@ public class UrlConfigLoader implements IConfigLoader {
 			}
 			clientRequest.getRequestHeaders().put(Headers.HOST, host);
 
-			// Send the request
 			AtomicReference<ClientResponse> responseReference = new AtomicReference<>();
 			CountDownLatch latch = new CountDownLatch(1);
 			connection.sendRequest(clientRequest, raw ? client.byteBufferClientCallback(responseReference, latch)


### PR DESCRIPTION
This PR removes an obvious comment (i.e. comment that restates what the code does in an obvious manner). The code itself is understandable that the request is being sent.