### PR TITLE
Issue 1820 - Add timeout option for the nonblocking calls

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -65,6 +65,14 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/consul/src/main/java/com/networknt/consul/ConsulConfig.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulConfig.java
@@ -28,6 +28,7 @@ public class ConsulConfig {
     boolean enableHttp2;
     String wait = "600s";                   // length of blocking query with Consul
     String timeoutBuffer = "5s";            // An additional amount of time to wait for Consul to respond (to account for network latency)
+    String nonBlockingWait = "5s";          // length of non blocking query with Consul
     long connectionTimeout = 5;             // Consul connection timeout in seconds
     long requestTimeout = 5;                // Consul request timeout in seconds (excluding /v1/health/service)
     long reconnectInterval = 2;             // Time to wait in seconds between reconnect attempts when Consul connection fails
@@ -122,4 +123,12 @@ public class ConsulConfig {
     public long getMaxAttemptsBeforeShutdown() { return maxAttemptsBeforeShutdown; }
 
     public boolean isShutdownIfThreadFrozen() { return shutdownIfThreadFrozen; }
+
+    public String getNonBlockingWait() {
+        return nonBlockingWait;
+    }
+
+    public void setNonBlockingWait(String nonBlockingWait) {
+        this.nonBlockingWait = nonBlockingWait;
+    }
 }

--- a/consul/src/main/java/com/networknt/consul/ConsulConfig.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulConfig.java
@@ -28,7 +28,6 @@ public class ConsulConfig {
     boolean enableHttp2;
     String wait = "600s";                   // length of blocking query with Consul
     String timeoutBuffer = "5s";            // An additional amount of time to wait for Consul to respond (to account for network latency)
-    String nonBlockingWait = "5s";          // length of non blocking query with Consul
     long connectionTimeout = 5;             // Consul connection timeout in seconds
     long requestTimeout = 5;                // Consul request timeout in seconds (excluding /v1/health/service)
     long reconnectInterval = 2;             // Time to wait in seconds between reconnect attempts when Consul connection fails
@@ -124,11 +123,4 @@ public class ConsulConfig {
 
     public boolean isShutdownIfThreadFrozen() { return shutdownIfThreadFrozen; }
 
-    public String getNonBlockingWait() {
-        return nonBlockingWait;
-    }
-
-    public void setNonBlockingWait(String nonBlockingWait) {
-        this.nonBlockingWait = nonBlockingWait;
-    }
 }

--- a/consul/src/main/java/com/networknt/consul/ConsulUtils.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulUtils.java
@@ -194,22 +194,4 @@ public class ConsulUtils {
         return w;
     }
 
-    /**
-     * convert the string timeoutBuffer to integer seconds from the config file. The possible format might be
-     * 600s or 10m etc. And the result will be 600 after the conversion.
-     *
-     * Default timeoutBuffer value is 5s
-     *
-     * @param timeoutBuffer String format of timeoutBuffer from the config
-     * @return int of the timeoutBuffer in seconds
-     */
-    public static int getNonBlockingTimeoutInSecond(String timeoutBuffer) {
-        int w = 5;
-        if(timeoutBuffer.endsWith("s")) {
-            w = Integer.valueOf(timeoutBuffer.substring(0, timeoutBuffer.length() - 1));
-        } else if (timeoutBuffer.endsWith("m")) {
-            w = Integer.valueOf(timeoutBuffer.substring(0, timeoutBuffer.length() - 1)) * 60;
-        }
-        return w;
-    }
 }

--- a/consul/src/main/java/com/networknt/consul/ConsulUtils.java
+++ b/consul/src/main/java/com/networknt/consul/ConsulUtils.java
@@ -193,4 +193,23 @@ public class ConsulUtils {
         }
         return w;
     }
+
+    /**
+     * convert the string timeoutBuffer to integer seconds from the config file. The possible format might be
+     * 600s or 10m etc. And the result will be 600 after the conversion.
+     *
+     * Default timeoutBuffer value is 5s
+     *
+     * @param timeoutBuffer String format of timeoutBuffer from the config
+     * @return int of the timeoutBuffer in seconds
+     */
+    public static int getNonBlockingTimeoutInSecond(String timeoutBuffer) {
+        int w = 5;
+        if(timeoutBuffer.endsWith("s")) {
+            w = Integer.valueOf(timeoutBuffer.substring(0, timeoutBuffer.length() - 1));
+        } else if (timeoutBuffer.endsWith("m")) {
+            w = Integer.valueOf(timeoutBuffer.substring(0, timeoutBuffer.length() - 1)) * 60;
+        }
+        return w;
+    }
 }

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
@@ -110,7 +110,7 @@ public class ConsulClientImpl implements ConsulClient {
 			connection = client.safeBorrowConnection(
 					config.getConnectionTimeout(), uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap);
 
-			int waitInSeconds = ConsulUtils.getWaitInSecond(nonBlockingWait);
+			int waitInSeconds = ConsulUtils.getNonBlockingTimeoutInSecond(nonBlockingWait);
 			AtomicReference<ClientResponse> reference = send(connection, Methods.PUT, path, token, null, waitInSeconds);
 			int statusCode = reference.get().getResponseCode();
 			if(statusCode >= UNUSUAL_STATUS_CODE){
@@ -133,7 +133,7 @@ public class ConsulClientImpl implements ConsulClient {
 			connection = client.safeBorrowConnection(
 					config.getConnectionTimeout(), uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap);
 
-			int waitInSeconds = ConsulUtils.getWaitInSecond(nonBlockingWait);
+			int waitInSeconds = ConsulUtils.getNonBlockingTimeoutInSecond(nonBlockingWait);
 			AtomicReference<ClientResponse> reference = send(connection, Methods.PUT, path, token, null, waitInSeconds);
 			int statusCode = reference.get().getResponseCode();
 			if(statusCode >= UNUSUAL_STATUS_CODE){
@@ -155,7 +155,7 @@ public class ConsulClientImpl implements ConsulClient {
 			connection = client.safeBorrowConnection(
 					config.getConnectionTimeout(), uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap);
 
-			int waitInSeconds = ConsulUtils.getWaitInSecond(nonBlockingWait);
+			int waitInSeconds = ConsulUtils.getNonBlockingTimeoutInSecond(nonBlockingWait);
 			AtomicReference<ClientResponse> reference = send(connection, Methods.PUT, path, token, json, waitInSeconds);
 			int statusCode = reference.get().getResponseCode();
 			if(statusCode >= UNUSUAL_STATUS_CODE){
@@ -177,7 +177,7 @@ public class ConsulClientImpl implements ConsulClient {
 			connection = client.safeBorrowConnection(
 					config.getConnectionTimeout(), uri, Http2Client.WORKER, Http2Client.SSL, Http2Client.BUFFER_POOL, optionMap);
 
-			int waitInSeconds = ConsulUtils.getWaitInSecond(nonBlockingWait);
+			int waitInSeconds = ConsulUtils.getNonBlockingTimeoutInSecond(nonBlockingWait);
 	        final AtomicReference<ClientResponse> reference = send(connection, Methods.PUT, path, token, null, waitInSeconds);
             int statusCode = reference.get().getResponseCode();
             if(statusCode >= UNUSUAL_STATUS_CODE){

--- a/consul/src/main/resources/config/consul.yml
+++ b/consul/src/main/resources/config/consul.yml
@@ -26,6 +26,8 @@ ttlCheck: true
 wait: 600s
 # Additional buffer of time to allow Consul to terminate the blocking query connection
 timeoutBuffer: 5s
+# Response timeout for the non blocking calls
+nonBlockingWait: 5s
 # enable HTTP/2
 # must disable when using HTTP with Consul (mostly using local Consul agent), Consul only supports HTTP/1.1 when not using TLS
 # optional to enable when using HTTPS with Consul, it will have better performance

--- a/consul/src/main/resources/config/consul.yml
+++ b/consul/src/main/resources/config/consul.yml
@@ -26,8 +26,6 @@ ttlCheck: true
 wait: 600s
 # Additional buffer of time to allow Consul to terminate the blocking query connection
 timeoutBuffer: 5s
-# Response timeout for the non blocking calls
-nonBlockingWait: 5s
 # enable HTTP/2
 # must disable when using HTTP with Consul (mostly using local Consul agent), Consul only supports HTTP/1.1 when not using TLS
 # optional to enable when using HTTPS with Consul, it will have better performance


### PR DESCRIPTION
Add timeout option for the nonblocking calls. 
Add wait/16 for the blocking calls, as suggested by Consul doc
Cleanup unused OptionMap initialization in ConsulClientImpl constructor and import.

Issue #1820
