### PR TITLE
Fix flaky test: com.networknt.audit.AuditHandlerTest.testAuditWithErrorStatus

### DIFF
--- a/audit/src/test/java/com/networknt/audit/AuditHandlerTest.java
+++ b/audit/src/test/java/com/networknt/audit/AuditHandlerTest.java
@@ -56,6 +56,7 @@ import org.xnio.OptionMap;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -168,8 +169,8 @@ public class AuditHandlerTest {
         verify(mockAppender, times(1)).doAppend(captorLoggingEvent.capture());
         ILoggingEvent event = captorLoggingEvent.getValue();
         Map<String, Object> mapValue = JsonMapper.string2Map(event.getFormattedMessage());
-
-        Assert.assertEquals("{statusCode=401, code=ERR10001, severity=ERROR, message=AUTH_TOKEN_EXPIRED, description=Jwt token in authorization header expired}", mapValue.get("Status").toString());
+        TreeMap<String, Object> treeMap = new TreeMap<>((Map<String, Object>) mapValue.get("Status"));
+        Assert.assertEquals("{code=ERR10001, description=Jwt token in authorization header expired, message=AUTH_TOKEN_EXPIRED, severity=ERROR, statusCode=401}", treeMap.toString());
     }
 
     private void verifyAuditInfo(String key, String value) {


### PR DESCRIPTION
### Problem
The test case [com.networknt.audit.AuditHandlerTest.testAuditWithErrorStatus](https://github.com/networknt/light-4j/blob/cf8bb530e341c3d6691ec62a553b1a764e3008c9/audit/src/test/java/com/networknt/audit/AuditHandlerTest.java#L167-L173) fails due to the below assertion

https://github.com/networknt/light-4j/blob/176eb7f338294c483b6c557ca2ef7911730129bd/audit/src/test/java/com/networknt/audit/AuditHandlerTest.java#L172

I found and confirmed the flaky behavior using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations. The assert statement fetches `Status` from mapValue which returns a `Map`. The order of the Map is not deterministic which may cause the assertion to fail when comparing it to the given Status string.

### Solution
This PR fixes the test by converting the `Map` returned by `mapValue.get("Status")` to a `TreeMap` with sorts the fields within the Map.

### Reproduce
The following command can be used to reproduce assertion failures and verify the fix:
```
mvn -pl edu.illinois:nondex-maven-plugin:2.1.1:nondex audit -Dtest=com.networknt.audit.AuditHandlerTest.testAuditWithErrorStatus
```

Test Environment:
```
Java version "1.8.0_381"
Apache Maven 3.6.3
macOS Venture Version 13.4.1 (22F82)
```

Please let me know if you have any concerns or questions.