### PR TITLE
[SWE637 FA23]: Fix body handler flaky test caused by invalid cast of string to java list

### DIFF
--- a/body/src/test/java/com/networknt/body/BodyHandlerTest.java
+++ b/body/src/test/java/com/networknt/body/BodyHandlerTest.java
@@ -112,9 +112,20 @@ public class BodyHandlerTest {
                             String resp = "";
                             if (map.size() > 0 && map.values().iterator().next() instanceof List) {
                                 resp = "{" + ((Map<String, FormData.FormValue>) body).entrySet().stream()
-                                        .map(entry -> entry.getKey() + ":" + "[" + ((List) entry.getValue()).stream()
+                                        .map(entry -> {
+                                            Object value = entry.getValue();
+                                            if (value instanceof List) {
+                                                // Handle List case
+                                                String listValue = ((List<?>) value).stream()
                                                 .map(n -> n instanceof FormData.FormValue ? ((FormData.FormValue) n).getValue() : n.toString())
-                                                .collect(Collectors.joining(",")) + "]")
+                                                        .collect(Collectors.joining(","));
+                                                return entry.getKey() + ":" + "[" + listValue + "]";
+                                            } else {
+                                                // Handle non-List case
+                                                return entry.getKey() + ":" + "[" + value.toString() + "]";
+
+                                            }
+                                        })
                                         .collect(Collectors.joining(",")) + "}";
                             } else {
                                 resp = "{" + ((Map<String, Object>) body).entrySet().stream()


### PR DESCRIPTION
In this change set, I addressed an issue related to handling form data and generating a response in a specific JSON-like format. The issue was causing a ClassCastException when attempting to cast a java.lang.String to a java.util.List. The change set aims to handle this situation more gracefully and ensure that the response is generated correctly.

**Purpose of this PR:**

The purpose of this pull request is to address an issue where a java.lang.ClassCastException was occurring in a particular section of the code. The issue was caused by attempting to cast a value to a List without checking its type, leading to a runtime error. This PR aims to fix the issue and improve the code's robustness.
Why the test fails and how to reproduce the test failure:

The test was failing due to a type mismatch when trying to cast a value to a List without checking its type. This occurred when the map contained non-List values. The failure can be reproduced by running the affected test case, which is trying to convert a map of form data into a JSON-like string representation.

**Expected results:**

The expected result is that the test case should pass without any exceptions, and the resulting resp string should accurately represent the form data in a JSON-like format.

**Actual results:**

Prior to this fix, the test was failing with a java.lang.ClassCastException when trying to cast a non-List value to a List. This resulted in an incomplete or incorrect resp string.

**Description of the fix:**

In this PR, the code was modified to first check the type of the value before attempting to cast it to a List. If the value is not a List, it is treated as a single value and converted to a string using toString(). If the value is a List, it is processed by mapping its elements and joining them with a comma to form a valid JSON-like representation. This change ensures that the code handles both List and non-List values correctly, preventing the java.lang.ClassCastException and producing the expected result.