### PR TITLE
Fixes #1908 - CRYPT regex too strict, only allows AES crypto alike strings

### DIFF
--- a/config/src/main/java/com/networknt/config/yml/YmlConstants.java
+++ b/config/src/main/java/com/networknt/config/yml/YmlConstants.java
@@ -6,6 +6,6 @@ import org.yaml.snakeyaml.nodes.Tag;
 
 public class YmlConstants {
 	public static final Tag CRYPT_TAG = new Tag(Tag.PREFIX + "crypt");
-	public static final Pattern CRYPT_PATTERN = Pattern.compile("CRYPT:[a-zA-Z0-9:=/+]+");
+	public static final Pattern CRYPT_PATTERN = Pattern.compile("^CRYPT:.*$");
 	public static final String CRYPT_FIRST = "C"; 
 }


### PR DESCRIPTION
CRYPT regexp in YmlConstants has been adapted only to allow AES alike passwords, rendering all previous passwords no longer valid. This regex also invalidates the possibility of using customised Decryptors.
This small changes fixes #1908, allowing in the future to use any kind of Decryptor.