### PR TITLE
fix NPE in SimpleConnectionPool.restore() and optimize borrow() with computeIfAbsent()

### DIFF
--- a/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionPool.java
@@ -41,16 +41,16 @@ public final class SimpleConnectionPool {
     public SimpleConnectionHolder.ConnectionToken borrow(long createConnectionTimeout, boolean isHttp2, URI uri)
         throws RuntimeException
     {
-        if(!pools.containsKey(uri)) {
-            synchronized (pools) {
-                if (!pools.containsKey(uri))
-                    pools.put(uri, new SimpleURIConnectionPool(uri, expireTime, poolSize, connectionMaker));
-            }
-        }
+        if(!pools.containsKey(uri))
+            pools.computeIfAbsent(uri, pool -> new SimpleURIConnectionPool(uri, expireTime, poolSize, connectionMaker));
+
         return pools.get(uri).borrow(createConnectionTimeout, isHttp2);
     }
 
     public void restore(SimpleConnectionHolder.ConnectionToken connectionToken) {
+        if(connectionToken == null)
+            return;
+
         if(pools.containsKey(connectionToken.uri()))
             pools.get(connectionToken.uri()).restore(connectionToken);
     }


### PR DESCRIPTION
Issue: https://github.com/networknt/light-4j/issues/1898

We can use the computeIfAbsent method of ConcurrentHashMap to add a new SimpleURIConnectionPool to a SimpleConnectionPool.

computeIfAbsent uses more efficient lock on the hashmap bucket for they uri key, rather than requiring synchronization on the entire ConcurrentHashMap.

Also we avoid creating an then discarding objects if the method is called after a value has already been put, since the lamda argument of computeIfAbsent is only executed if a value does not already exist.

Additionally, there is a missing NP check in the restore method.