### PR TITLE
Update client module unit tests to allows sub-1ms response times (Issue 1950)

### DIFF
--- a/client/src/test/java/com/networknt/client/Http2ClientPoolTest.java
+++ b/client/src/test/java/com/networknt/client/Http2ClientPoolTest.java
@@ -286,7 +286,7 @@ public class Http2ClientPoolTest {
             final AsyncResult<AsyncResponse> ar = reference.get();
             if(ar.succeeded()) {
                 Assert.assertEquals(message, ar.result().getResponseBody());
-                Assert.assertTrue(ar.result().getResponseTime() > 0);
+                Assert.assertTrue(ar.result().getResponseTime() >= 0);
                 System.out.println("responseTime = " + ar.result().getResponseTime());
             } else {
                 ar.cause().printStackTrace();

--- a/client/src/test/java/com/networknt/client/Http2ClientTest.java
+++ b/client/src/test/java/com/networknt/client/Http2ClientTest.java
@@ -525,7 +525,7 @@ public class Http2ClientTest {
             final AsyncResult<AsyncResponse> ar = reference.get();
             if(ar.succeeded()) {
                 Assert.assertEquals(message, ar.result().getResponseBody());
-                Assert.assertTrue(ar.result().getResponseTime() > 0);
+                Assert.assertTrue(ar.result().getResponseTime() >= 0);
                 System.out.println("responseTime = " + ar.result().getResponseTime());
             } else {
                 ar.cause().printStackTrace();


### PR DESCRIPTION
Issue: https://github.com/networknt/light-4j/issues/1950

Update client module unit tests to allow sub-1ms response times