### PR TITLE
revert upgrades of snakeyaml and jackson until compatibility updates made (1.6.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <java.version>8</java.version>
         <javac.version>9+181-r4173-1</javac.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.jackson>2.15.3</version.jackson>
+        <version.jackson>2.14.0</version.jackson>
         <version.slf4j>1.7.36</version.slf4j>
         <version.jose4j>0.6.3</version.jose4j>
         <version.commons.codec>1.15</version.commons.codec>
@@ -86,7 +86,7 @@
         <version.zookeeper>3.5.3-beta</version.zookeeper>
         <version.zkclient>0.3</version.zkclient>
         <version.curator>4.0.1</version.curator>
-        <version.snakeyaml>2.2</version.snakeyaml>
+        <version.snakeyaml>1.33</version.snakeyaml>
         <version.caffeine>2.6.2</version.caffeine>
         <version.prometheus>0.6.0</version.prometheus>
         <version.javamail>1.6.1</version.javamail>


### PR DESCRIPTION
Issue: https://github.com/networknt/light-4j/issues/1958

Recent commits to the light-4j 1.6.x branch have updated snakeyaml to 2.2 and Jackson to 2.15.3.

However, these dependency updates are not compatible with the current light-4j 1.6.x code-base.

Numerous code changes must be made to light-4j code base to make light-4j 1.6.x compatible with these updated dependency versions.

For example, snakeyaml 2.2 has changed numerous previously-zero-argument constructors to constructors that require arguments causing compilation failures. Jackson has deprecated certain TimeZone classes that are causing existing unit tests to fail.

The dependency version updates cannot be made alone without the code changes needed to make the codebase properly work with the changes in snakeyaml 2.2 and Jackson 2.15.3.

See discussions on the need for the downgrades here (snakeyaml):

https://github.com/networknt/light-4j/commit/adc91967e24e66342c23d7853c785ece221e496e#commitcomment-131730044

and here (jackson):

https://github.com/networknt/light-4j/commit/0c83580adcae8e34bd4da1ac6dc281134f10a2fc#commitcomment-131731260

```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  23.921 s
[INFO] Finished at: 2023-11-04T20:36:11-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project config: Compilation failure: Compilation failure:
[ERROR] /Users/miklish/localrepo2/CP214-BUILD-ERROR/light-4j/config/src/main/java/com/networknt/config/Config.java:[161,66] error: constructor Representer in class Representer cannot be applied to given types;
[ERROR]   required: DumperOptions
[ERROR]   found: no arguments
[ERROR]   reason: actual and formal argument lists differ in length
[ERROR] /Users/miklish/localrepo2/CP214-BUILD-ERROR/light-4j/config/src/main/java/com/networknt/config/yml/ConfigLoaderConstructor.java:[19,8] error: no suitable constructor found for Constructor(no arguments)
[ERROR]     constructor Constructor.Constructor(LoaderOptions) is not applicable
[ERROR]       (actual and formal argument lists differ in length)
[ERROR]     constructor Constructor.Constructor(Class<? extends Object>,LoaderOptions) is not applicable
[ERROR]       (actual and formal argument lists differ in length)
[ERROR]     constructor Constructor.Constructor(TypeDescription,LoaderOptions) is not applicable
[ERROR]       (actual and formal argument lists differ in length)
[ERROR]     constructor Constructor.Constructor(TypeDescription,Collection<TypeDescription>,LoaderOptions) is not applicable
[ERROR]       (actual and formal argument lists differ in length)
[ERROR]     constructor Constructor.Constructor(String,LoaderOptions) is not applicable
[ERROR]       (actual and formal argument lists differ in length)
[ERROR] /Users/miklish/localrepo2/CP214-BUILD-ERROR/light-4j/config/src/main/java/com/networknt/config/yml/DecryptConstructor.java:[32,2] error: no suitable constructor found for Constructor(no arguments)
[ERROR]     constructor Constructor.Constructor(LoaderOptions) is not applicable
[ERROR]       (actual and formal argument lists differ in length)
[ERROR]     constructor Constructor.Constructor(Class<? extends Object>,LoaderOptions) is not applicable
[ERROR]       (actual and formal argument lists differ in length)
[ERROR]     constructor Constructor.Constructor(TypeDescription,LoaderOptions) is not applicable
[ERROR]       (actual and formal argument lists differ in length)
[ERROR]     constructor Constructor.Constructor(TypeDescription,Collection<TypeDescription>,LoaderOptions) is not applicable
[ERROR]       (actual and formal argument lists differ in length)
[ERROR]     constructor Constructor.Constructor(String,LoaderOptions) is not applicable
[ERROR]       (actual and formal argument lists differ in length)
```