### PR TITLE
SimplePool v2

### DIFF
--- a/client/src/main/java/com/networknt/client/oauth/OauthHelper.java
+++ b/client/src/main/java/com/networknt/client/oauth/OauthHelper.java
@@ -20,9 +20,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.networknt.client.ClientConfig;
 import com.networknt.client.Http2Client;
-import com.networknt.client.simplepool.SimpleConnectionHolder;
+import com.networknt.client.simplepool.SimpleConnectionState;
 import com.networknt.client.simplepool.SimpleConnectionPool;
-import com.networknt.client.simplepool.undertow.SimpleClientConnectionMaker;
+import com.networknt.client.simplepool.undertow.SimpleUndertowConnectionMaker;
 import com.networknt.cluster.Cluster;
 import com.networknt.config.Config;
 import com.networknt.exception.ClientException;
@@ -88,7 +88,7 @@ public class OauthHelper {
     private static final Logger logger = LoggerFactory.getLogger(OauthHelper.class);
 
     private static final SimpleConnectionPool pool = new SimpleConnectionPool(
-            ClientConfig.get().getConnectionExpireTime(), ClientConfig.get().getConnectionPoolSize(), SimpleClientConnectionMaker.instance());
+            ClientConfig.get().getConnectionExpireTime(), ClientConfig.get().getConnectionPoolSize(), SimpleUndertowConnectionMaker.instance());
 
     /**
      * @deprecated As of release 1.5.29, replaced with @link #getTokenResult(TokenRequest tokenRequest)
@@ -413,7 +413,7 @@ public class OauthHelper {
         final Http2Client client = Http2Client.getInstance();
         final CountDownLatch latch = new CountDownLatch(1);
         ClientConnection connection = null;
-        SimpleConnectionHolder.ConnectionToken borrowToken = null;
+        SimpleConnectionState.ConnectionToken borrowToken = null;
 
         long connectionTimeout = Math.max(2, keyRequest.getKeyConnectionTimeout() / 1000);
         long populateKeyTimeout = Math.max(2, keyRequest.getPopulateKeyTimeout() / 1000);

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleConnection.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleConnection.java
@@ -22,7 +22,7 @@ package com.networknt.client.simplepool;
 
 /***
  * SimpleConnection is an interface that contains all the required functions and properties of
- * a connection that are needed by the SimpleConnectionHolder, SimpleURIConnectionPool, and
+ * a connection that are needed by the SimpleConnectionState, SimpleURIConnectionPool, and
  * SimpleConnectionPool classes.
  *
  * Concrete HTTP network connections (like Undertow's ClientConnection class) should be wrapped in

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionMaker.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionMaker.java
@@ -24,10 +24,46 @@ import java.util.Set;
 
 /***
  * A factory that creates raw connections and wraps them in SimpleConnection objects.
- * SimpleConnectionMakers are used by SimpleConnectionHolders to create connections.
+ * SimpleConnectionMakers are used by SimpleConnectionStates to create connections.
  *
  */
 public interface SimpleConnectionMaker {
-    public SimpleConnection makeConnection(long createConnectionTimeout, boolean isHttp2, final URI uri, final Set<SimpleConnection> allCreatedConnections);
-    public SimpleConnection reuseConnection(long createConnectionTimeout, SimpleConnection connection) throws RuntimeException;
+    /***
+     * Establishes a new connection to a URI.
+     * Implementations of SimpleConnectionMaker are used by SimpleConnectionStates as a connection factory.
+     *
+     * @param createConnectionTimeout the maximum time in seconds to wait for a connection to be established
+     * @param isHttp2 if true, SimpleConnectionMaker must attempt to establish an HTTP/2 connection, otherwise it will
+     *          attempt to create an HTTP/1.1 connection
+     * @param uri the URI to connect to
+     * @param allCreatedConnections Implementations of SimpleConnectionMaker are used by SimpleConnectionState to create
+     *          connections to arbitrary URIs. In other words, implementations of SimpleConnectionMaker are used by
+     *          SimpleConnectionState as a connection factory.
+     *
+     *          A SimpleConnectionMaker will add all connections it creates to the Set <code>allCreatedConnections</code>.
+     *          SimpleURIConnectionPool will compare the connections in this Set to those that it is tracking and close
+     *          any untracked connections.
+     *
+     *          Untracked connections can occur if there is a connection creation timeout. When such a timeout occurs,
+     *          makeConnection() must throw a RuntimeException which will prevent SimpleURIConnectionPool from acquiring
+     *          a SimpleConnection. However, the connection creation callback thread in makeConnection() may continue to
+     *          execute after the timeout and ultimately succeed in creating the connection after the timeout has occurred
+     *          and the exception has been thrown. Connections that are created but were not returned to
+     *          SimpleURIConnectionPool are considered to be 'untracked'.
+     *
+     *          Despite not being tracked by SimpleURIConnectionPool, all successfully created connections must be added
+     *          to <code>allCreatedConnections</code>.
+     *
+     *          SimpleURIConnectionPool prevents these untracked connections from accumulating and causing a connection
+     *          leak over time, by periodically closing any open connections in allCreatedConnections that it is not tracking.
+     *
+     *          Thread Safety:
+     *              allCreatedConnections MUST be a threadsafe Set, or the thread safety of the connection pool cannot
+     *              be guaranteed.
+     *
+     * @return A SimpleConnection to the specified URI
+     * @throws RuntimeException thrown if the connection establishment timeout (<code>createConnectionTimeout</code>)
+     *          expires before a connection to the URI is established, or if there is an error establishing the connection
+     */
+    public SimpleConnection makeConnection(long createConnectionTimeout, boolean isHttp2, final URI uri, final Set<SimpleConnection> allCreatedConnections) throws RuntimeException;
 }

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionPool.java
@@ -24,7 +24,11 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * This is a class through which multiple URI Connection Pools can be accessed
+ *     SimpleConnectionPool is a connection pool, which means that it manages a pool of reusable network connections.
+ *     Threads borrow connections from the pool, use them, and then return them back to the pool. Once returned, these
+ *     connections can then be borrowed by other threads. Since these returned connections are already active / established,
+ *     they can be used immediately without going through the lengthy connection establishment process. This can very
+ *     significantly increase the performance of systems that make many simultaneous outgoing API calls.
  */
 public final class SimpleConnectionPool {
     private final Map<URI, SimpleURIConnectionPool> pools = new ConcurrentHashMap<>();
@@ -32,21 +36,49 @@ public final class SimpleConnectionPool {
     private final long expireTime;
     private final int poolSize;
 
+    /***
+     * Creates a SimpleConnectionPool
+     *
+     * @param expireTime the length of time in milliseconds a connection is eligible to be borrowed
+     * @param poolSize the maximum number of unexpired connections the pool can hold at a given time
+     * @param connectionMaker a class that SimpleConnectionPool uses to create new connections
+     */
     public SimpleConnectionPool(long expireTime, int poolSize, SimpleConnectionMaker connectionMaker) {
         this.expireTime = expireTime;
         this.poolSize = poolSize;
         this.connectionMaker = connectionMaker;
     }
 
+    /***
+     * Returns a network connection to a URI
+     *
+     * @param createConnectionTimeout The maximum time in seconds to wait for a new connection to be established before
+     *          throwing an exception
+     * @param isHttp2 if true, SimpleURIConnectionPool will attempt to establish an HTTP/2 connection, otherwise it will
+     *          attempt to create an HTTP/1.1 connection
+     * @return  a ConnectionToken object that contains the borrowed connection. The thread using the connection must
+     *          return this connection to the pool when it is done with it by calling the borrow() method with the
+     *          ConnectionToken as the argument
+     * @throws RuntimeException if connection creation takes longer than <code>createConnectionTimeout</code> seconds,
+     *          or other issues that prevent connection creation
+     */
     public SimpleConnectionState.ConnectionToken borrow(long createConnectionTimeout, boolean isHttp2, URI uri)
-        throws RuntimeException
+            throws RuntimeException
     {
         if(!pools.containsKey(uri))
             pools.computeIfAbsent(uri, pool -> new SimpleURIConnectionPool(uri, expireTime, poolSize, connectionMaker));
-
         return pools.get(uri).borrow(createConnectionTimeout, isHttp2);
     }
 
+    /***
+     * Restores borrowed connections
+     *
+     * NOTE: A connection that unexpectedly closes may be removed from connection pool tracking before all of its
+     *       ConnectionTokens have been restored. This can result in seeing log messages about CLOSED connections
+     *       being restored to the pool that are no longer tracked / known by the connection pool
+     *
+     * @param connectionToken the connection token that represents the borrowing of a connection by a thread
+     */
     public void restore(SimpleConnectionState.ConnectionToken connectionToken) {
         if(connectionToken == null)
             return;

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionPool.java
@@ -38,7 +38,7 @@ public final class SimpleConnectionPool {
         this.connectionMaker = connectionMaker;
     }
 
-    public SimpleConnectionHolder.ConnectionToken borrow(long createConnectionTimeout, boolean isHttp2, URI uri)
+    public SimpleConnectionState.ConnectionToken borrow(long createConnectionTimeout, boolean isHttp2, URI uri)
         throws RuntimeException
     {
         if(!pools.containsKey(uri))
@@ -47,7 +47,7 @@ public final class SimpleConnectionPool {
         return pools.get(uri).borrow(createConnectionTimeout, isHttp2);
     }
 
-    public void restore(SimpleConnectionHolder.ConnectionToken connectionToken) {
+    public void restore(SimpleConnectionState.ConnectionToken connectionToken) {
         if(connectionToken == null)
             return;
 

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionPool.java
@@ -67,6 +67,7 @@ public final class SimpleConnectionPool {
     {
         if(!pools.containsKey(uri))
             pools.computeIfAbsent(uri, pool -> new SimpleURIConnectionPool(uri, expireTime, poolSize, connectionMaker));
+        
         return pools.get(uri).borrow(createConnectionTimeout, isHttp2);
     }
 

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 
 /***
- * A SimpleConnectionHolder is a simplified interface for a connection, that also keeps track of the connection's state.
+ * A SimpleConnectionState is a simplified interface for a connection, that also keeps track of the connection's state.
  * (In fact--in this document--the state of a connection and the state of its holder are used interchangeably)
  *
  * Connection States
@@ -84,8 +84,8 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  *   Not doing so (i.e.: not freezing the time) may allow inconsistent states to be reached.
  */
-public final class SimpleConnectionHolder {
-    private static final Logger logger = LoggerFactory.getLogger(SimpleConnectionHolder.class);
+public final class SimpleConnectionState {
+    private static final Logger logger = LoggerFactory.getLogger(SimpleConnectionState.class);
 
     // how long a connection can be eligible to be borrowed
     private final long EXPIRE_TIME;
@@ -120,7 +120,7 @@ public final class SimpleConnectionHolder {
      * Connections and ConnectionHolders are paired 1-1. For every connection there is a single ConnectionHolder and
      * vice versa.
      *
-     * This is why connections are created at the same time a ConnectionHolder is created (see SimpleConnectionHolder
+     * This is why connections are created at the same time a ConnectionHolder is created (see SimpleConnectionState
      * constructor).
      *
      * The connection holder acts as a simplified interface to the connection, and keeps track of how many
@@ -134,9 +134,9 @@ public final class SimpleConnectionHolder {
      * @param allCreatedConnections this Set will be passed to the callback thread that creates the connection.
      *                              The connectionMaker will always add every successfully created connection
      *                              to this Set.
-     * @param connectionMaker a class that SimpleConnectionHolder uses to create new SimpleConnection objects
+     * @param connectionMaker a class that SimpleConnectionState uses to create new SimpleConnection objects
      */
-    public SimpleConnectionHolder(
+    public SimpleConnectionState(
         long expireTime,
         long connectionCreateTimeout,
         boolean isHttp2,
@@ -325,24 +325,24 @@ public final class SimpleConnectionHolder {
     }
 
     /**
-     * Returns the SimpleConnection that SimpleConnectionHolder holds
+     * Returns the SimpleConnection that SimpleConnectionState holds
      *
-     * @return the SimpleConnection that SimpleConnectionHolder holds
+     * @return the SimpleConnection that SimpleConnectionState holds
      */
     public SimpleConnection connection() { return connection; }
 
     public class ConnectionToken {
         private final SimpleConnection connection;
-        private final SimpleConnectionHolder holder;
+        private final SimpleConnectionState holder;
         private final URI uri;
 
         ConnectionToken(SimpleConnection connection) {
             this.connection = connection;
-            this.holder = SimpleConnectionHolder.this;
-            this.uri = SimpleConnectionHolder.this.uri;
+            this.holder = SimpleConnectionState.this;
+            this.uri = SimpleConnectionState.this.uri;
         }
 
-        SimpleConnectionHolder holder() { return holder; }
+        SimpleConnectionState holder() { return holder; }
         SimpleConnection connection() { return connection; }
         public Object getRawConnection() { return connection.getRawConnection(); }
         public URI uri() { return uri; }

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
@@ -157,7 +157,7 @@ public final class SimpleConnectionState {
 
         // throw exception if connection creation failed
         if(!connection.isOpen()) {
-            logger.debug("{} closed connection", logLabel(connection, now));
+            if(logger.isDebugEnabled()) logger.debug("{} closed connection", logLabel(connection, now));
             throw new RuntimeException("[" + port(connection) + "] Error creating connection to " + uri.toString());
 
             // start life-timer and determine connection type
@@ -167,7 +167,8 @@ public final class SimpleConnectionState {
             // HTTP/1.1 connections have a MAX_BORROW of 1, while HTTP/2 connections can have > 1 MAX_BORROWS
             MAX_BORROWS = connection().isMultiplexingSupported() ? Integer.MAX_VALUE : 1;
 
-            logger.debug("{} New connection : {}", logLabel(connection, now), MAX_BORROWS > 1 ? "HTTP/2" : "HTTP/1.1");
+            if(logger.isDebugEnabled())
+                logger.debug("{} New connection : {}", logLabel(connection, now), MAX_BORROWS > 1 ? "HTTP/2" : "HTTP/1.1");
         }
     }
 
@@ -210,7 +211,8 @@ public final class SimpleConnectionState {
             // add connectionToken to the Set of borrowed tokens
             borrowedTokens.add( (connectionToken = new ConnectionToken(connection)) );
 
-            logger.debug("{} borrow - connection now has {} borrows", logLabel(connection, now), borrowedTokens.size());
+            if(logger.isDebugEnabled())
+                logger.debug("{} borrow - connection now has {} borrows", logLabel(connection, now), borrowedTokens.size());
 
             return connectionToken;
         }
@@ -234,7 +236,8 @@ public final class SimpleConnectionState {
         borrowedTokens.remove(connectionToken);
 
         long now = System.currentTimeMillis();
-        logger.debug("{} restore - connection now has {} borrows", logLabel(connection, now), borrowedTokens.size());
+        if(logger.isDebugEnabled())
+            logger.debug("{} restore - connection now has {} borrows", logLabel(connection, now), borrowedTokens.size());
     }
 
     /**
@@ -244,7 +247,8 @@ public final class SimpleConnectionState {
      * @return true if the connection was closed and false otherwise
      */
     public synchronized boolean safeClose(long now) {
-        logger.debug("{} close - closing connection with {} borrows...", logLabel(connection, now), borrowedTokens.size());
+        if(logger.isDebugEnabled())
+            logger.debug("{} close - closing connection with {} borrows...", logLabel(connection, now), borrowedTokens.size());
 
         /**
          Connection may still be open even if closed == true

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /***
  * A SimpleConnectionState is a simplified interface for a connection, that also keeps track of the connection's state.
- * (In fact--in this document--the state of a connection and the state of its holder are used interchangeably)
+ * (In fact--in this document--a connection and its state are used interchangeably)
  *
  * Connection States
  *
@@ -87,65 +87,65 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class SimpleConnectionState {
     private static final Logger logger = LoggerFactory.getLogger(SimpleConnectionState.class);
 
-    // how long a connection can be eligible to be borrowed
+    // how long in milliseconds a connection can be eligible to be borrowed
     private final long EXPIRE_TIME;
 
     // the maximum number of borrowed tokens a connection can have at a time
     private final int MAX_BORROWS;
 
-    // the time this connection was created
+    // the time this connection was created represented as Unix Epoch time in milliseconds
     private final long startTime;
 
     // the URI this connection is connected to
     private final URI uri;
 
     /**
-      if true, this connection should be treated as CLOSED
-      note: CLOSED may be true before a connection is actually closed since there may be a delay
-            between setting close = false, and the network connection actually being fully closed
-    */
+     if true, this connection should be treated as CLOSED
+     note: CLOSED may be true before a connection is actually closed since there may be a delay
+     between setting close = false, and the network connection actually being fully closed
+     */
     private volatile boolean closed = false;
 
     /**
-      If the connection is HTTP/1.1, it can only be borrowed by 1 process at a time
-      If the connection is HTTP/2, it can be borrowed by an unlimited number of processes at a time
-    */
-    private final SimpleConnectionMaker connectionMaker;
+     If the connection is HTTP/1.1, it can only be borrowed by 1 thread at a time
+     If the connection is HTTP/2, it can be borrowed by an unlimited number of threads at a time
+     */
     private final SimpleConnection connection;
 
     /** a Set containing all borrowed connection tokens */
     private final Set<ConnectionToken> borrowedTokens = ConcurrentHashMap.newKeySet();
 
     /***
-     * Connections and ConnectionHolders are paired 1-1. For every connection there is a single ConnectionHolder and
+     * Connections and ConnectionStates are paired 1-1. For every connection there is a single ConnectionState and
      * vice versa.
      *
-     * This is why connections are created at the same time a ConnectionHolder is created (see SimpleConnectionState
+     * This is why connections are created at the same time a ConnectionState is created (see SimpleConnectionState
      * constructor).
      *
-     * The connection holder acts as a simplified interface to the connection, and keeps track of how many
-     * processes are using it at any given time. The maximum number of processes using it at the same time
-     * is determined by the connections type: HTTP/1.1 (1 process at a time) or HTTP/2 (multiple processes at a time).
+     * The SimpleConnectionState acts as a simplified interface to the connection, and keeps track of how many
+     * threads are using it at any given time. The maximum number of threads that can use it at the same time
+     * is determined by the connection's type: HTTP/1.1 (1 thread at a time) or HTTP/2 (multiple threads at a time).
      *
-     * @param expireTime how long a connection is eligible to be borrowed
-     * @param connectionCreateTimeout how long it can take a connection be created before an exception thrown
+     * @param expireTime the length of time in milliseconds a connection is eligible to be borrowed
+     * @param connectionCreateTimeout The maximum time in seconds to wait for a new connection to be established before
+     *          throwing an exception
      * @param isHttp2 if true, tries to upgrade to HTTP/2. if false, will try to open an HTTP/1.1 connection
      * @param uri the URI the connection will try to connect to
      * @param allCreatedConnections this Set will be passed to the callback thread that creates the connection.
-     *                              The connectionMaker will always add every successfully created connection
-     *                              to this Set.
+     *          The connectionMaker will always add every successfully created connection to this Set. This Set must be
+     *          threadsafe (such as <code>ConcurrentHashMap.newKeySet()</code>)
      * @param connectionMaker a class that SimpleConnectionState uses to create new SimpleConnection objects
+     * @throws RuntimeException thrown if connection cannot be established within <code>connectionCreateTimeout</code>
+     *          seconds or prematurely closes
      */
     public SimpleConnectionState(
-        long expireTime,
-        long connectionCreateTimeout,
-        boolean isHttp2,
-        URI uri,
-        Set<SimpleConnection> allCreatedConnections,
-        SimpleConnectionMaker connectionMaker)
+            long expireTime,
+            long connectionCreateTimeout,
+            boolean isHttp2,
+            URI uri,
+            Set<SimpleConnection> allCreatedConnections,
+            SimpleConnectionMaker connectionMaker) throws RuntimeException
     {
-        this.connectionMaker = connectionMaker;
-
         this.uri = uri;
         EXPIRE_TIME = expireTime;
 
@@ -160,7 +160,7 @@ public final class SimpleConnectionState {
             logger.debug("{} closed connection", logLabel(connection, now));
             throw new RuntimeException("[" + port(connection) + "] Error creating connection to " + uri.toString());
 
-        // start life-timer and determine connection type
+            // start life-timer and determine connection type
         } else {
             startTime = System.currentTimeMillis();
 
@@ -171,47 +171,44 @@ public final class SimpleConnectionState {
         }
     }
 
-    private volatile boolean firstUse = true;
     /**
      * State Transition - Borrow
      *
-     * @param connectionCreateTimeout the amount of time to wait for a connection to be created before throwing an exception
-     * @param now the time at which to evaluate whether there are borrowable connections or not
-     * @return returns a ConnectionToken representing this borrow of the connection
-     * @throws RuntimeException if connection closed or attempt to borrow after pool is full
+     * @param connectionCreateTimeout the amount of time in seconds to wait for a connection to be created before
+     *          throwing an exception
+     * @param now the Unix Epoch time in milliseconds at which to evaluate whether there are borrowable connections or not
+     * @return returns a ConnectionToken representing the borrowing of the connection
+     * @throws RuntimeException if the connection is closed
+     * @throws IllegalStateException if the connection is not borrowable
      */
     public synchronized ConnectionToken borrow(long connectionCreateTimeout, long now) throws RuntimeException {
         /***
          * Connections can only be borrowed when the connection is in a BORROWABLE state.
          *
          * This will throw an IllegalStateException if borrow is called when the connection is not borrowable.
-         * This means that users need to check the state of the connection (i.e.: the state of the ConnectionHolder)
+         * This means that users need to check the state of the connection (i.e.: the state of the ConnectionState)
          * before using it, e.g.:
          *
          *     ConnectionToken connectionToken = null;
          *     long now = System.currentTimeMillis();
          *
-         *     if(connectionHolder.borrowable(now))
-         *         connectionToken = connectionHolder.borrow(connectionCreateTimeout, now);
+         *     if(connectionState.borrowable(now))
+         *         connectionToken = connectionState.borrow(connectionCreateTimeout, now);
          *
          * Also note the use of a single consistent value for the current time ('now'). This ensures
          * that the state returned in the 'if' statement will still be true in the 'borrow' statement
          * (as long as the connection does not close between the 'if' and 'borrow').
          *
          */
+
         ConnectionToken connectionToken;
 
         if(borrowable(now)) {
-            if (firstUse) {
-                firstUse = false;
-                connectionToken = new ConnectionToken(connection);
-            } else {
-                SimpleConnection reusedConnection = connectionMaker.reuseConnection(connectionCreateTimeout, connection);
-                connectionToken = new ConnectionToken(reusedConnection);
-            }
+            if(closed())
+                throw new RuntimeException("Connection was unexpectedly closed");
 
             // add connectionToken to the Set of borrowed tokens
-            borrowedTokens.add(connectionToken);
+            borrowedTokens.add( (connectionToken = new ConnectionToken(connection)) );
 
             logger.debug("{} borrow - connection now has {} borrows", logLabel(connection, now), borrowedTokens.size());
 
@@ -243,25 +240,25 @@ public final class SimpleConnectionState {
     /**
      * State Transition - Close
      *
-     * @param now the time at which to evaluate whether this connection is closable or not
+     * @param now the Unix Epoch time in milliseconds at which to evaluate whether this connection is closable or not
      * @return true if the connection was closed and false otherwise
      */
     public synchronized boolean safeClose(long now) {
         logger.debug("{} close - closing connection with {} borrows...", logLabel(connection, now), borrowedTokens.size());
 
         /**
-        Connection may still be open even if closed == true
-        However, for consistency, we treat the connection as closed as soon as closed == true,
-        even if IoUtils.safeClose(connection) has not completed closing the connection yet
-        */
+         Connection may still be open even if closed == true
+         However, for consistency, we treat the connection as closed as soon as closed == true,
+         even if IoUtils.safeClose(connection) has not completed closing the connection yet
+         */
         if(closed())
             return true;
 
         /**
-        Ensures that a connection is never closed unless the connection is in the NOT_BORROWED_EXPIRED state
-        This is vital to ensure that connections are never closed until after all processes that
-        borrowed them are no longer using them
-        */
+         Ensures that a connection is never closed unless the connection is in the NOT_BORROWED_EXPIRED state
+         This is vital to ensure that connections are never closed until after all threads that
+         borrowed them are no longer using them
+         */
         boolean notBorrowedExpired = !borrowed() && expired(now);
         if(notBorrowedExpired != true)
             throw new IllegalStateException();
@@ -289,7 +286,7 @@ public final class SimpleConnectionState {
     /**
      * State Property - isExpired
      *
-     * @param now the time at which to evaluate whether this connection has expired or not
+     * @param now the Unix Epoch time in milliseconds at which to evaluate whether this connection has expired or not
      * @return true if the connection has expired and false otherwise
      */
     public synchronized boolean expired(long now) {
@@ -307,7 +304,7 @@ public final class SimpleConnectionState {
 
     /**
      * State Property - isAtMaxBorrows
-     * 
+     *
      * @return true if the connection is at its maximum number of borrows, and false otherwise
      */
     public synchronized boolean maxBorrowed() {
@@ -317,7 +314,7 @@ public final class SimpleConnectionState {
     /**
      * State Property - isBorrowable
      *
-     * @param now the time at which to evaluate the borrowability of this connection
+     * @param now the Unix Epoch time in milliseconds at which to evaluate the borrowability of this connection
      * @return true if the connection is borrowable and false otherwise
      */
     public synchronized boolean borrowable(long now) {
@@ -333,16 +330,16 @@ public final class SimpleConnectionState {
 
     public class ConnectionToken {
         private final SimpleConnection connection;
-        private final SimpleConnectionState holder;
+        private final SimpleConnectionState connectionState;
         private final URI uri;
 
         ConnectionToken(SimpleConnection connection) {
             this.connection = connection;
-            this.holder = SimpleConnectionState.this;
+            this.connectionState = SimpleConnectionState.this;
             this.uri = SimpleConnectionState.this.uri;
         }
 
-        SimpleConnectionState holder() { return holder; }
+        SimpleConnectionState state() { return connectionState; }
         SimpleConnection connection() { return connection; }
         public Object getRawConnection() { return connection.getRawConnection(); }
         public URI uri() { return uri; }

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -114,7 +114,7 @@ public final class SimpleURIConnectionPool {
         SimpleConnectionState.ConnectionToken connectionToken = connectionState.borrow(createConnectionTimeout, now);
         applyConnectionState(connectionState, now, () -> trackedConnections.remove(connectionState));
 
-        logger.debug(showConnections("borrow"));
+        if(logger.isDebugEnabled()) logger.debug(showConnections("borrow"));
 
         findAndCloseLeakedConnections();
         return connectionToken;
@@ -142,7 +142,7 @@ public final class SimpleURIConnectionPool {
         // update the connection pool's state
         applyAllConnectionStates(now);
 
-        logger.debug(showConnections("restore"));
+        if(logger.isDebugEnabled()) logger.debug(showConnections("restore"));
     }
 
     /**
@@ -195,7 +195,8 @@ public final class SimpleURIConnectionPool {
          * (and will therefore be garbage collected)
          */
         if(connection.closed()) {
-            logger.debug("[{}: CLOSED]: Connection unexpectedly closed - Stopping connection tracking", port(connection.connection()));
+            if(logger.isDebugEnabled())
+                logger.debug("[{}: CLOSED]: Connection unexpectedly closed - Stopping connection tracking", port(connection.connection()));
 
             removeFromConnectionTracking(connection, trackedConnectionRemover);
             return;
@@ -217,7 +218,8 @@ public final class SimpleURIConnectionPool {
             connection.safeClose(now);
             removeFromConnectionTracking(connection, trackedConnectionRemover);
 
-            logger.debug("[{}: CLOSED]: Expired connection was closed - Connection tracking stopped", port(connection.connection()));
+            if(logger.isDebugEnabled())
+                logger.debug("[{}: CLOSED]: Expired connection was closed - Connection tracking stopped", port(connection.connection()));
         }
     }
 
@@ -280,7 +282,7 @@ public final class SimpleURIConnectionPool {
 
         // any remaining connections are leaks, and can now be safely closed
         if(allCreatedConnections.size() > 0) {
-            logger.debug("{} untracked connection(s) found", allCreatedConnections.size());
+            if(logger.isDebugEnabled()) logger.debug("{} untracked connection(s) found", allCreatedConnections.size());
 
             Iterator<SimpleConnection> leakedConnections = allCreatedConnections.iterator();
             while(leakedConnections.hasNext()) {
@@ -288,9 +290,10 @@ public final class SimpleURIConnectionPool {
 
                 if(leakedConnection.isOpen()) {
                     leakedConnection.safeClose();
-                    logger.debug("Connection closed {} -> {}", port(leakedConnection), uri.toString());
-                } else
-                    logger.debug("Connection was already closed {} -> {}", port(leakedConnection), uri.toString());
+                    if(logger.isDebugEnabled()) logger.debug("Connection closed {} -> {}", port(leakedConnection), uri.toString());
+                } else {
+                    if (logger.isDebugEnabled()) logger.debug("Connection was already closed {} -> {}", port(leakedConnection), uri.toString());
+                }
 
                 leakedConnections.remove();
             }

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -28,15 +28,21 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 
 /***
-    A connection pool for a single URI.
-    Connection pool contains 4 Sets of ConnectionHolders:
+ SimpleURIConnectionPool is a connection pool for a single URI, which means that it manages a pool of reusable
+ connections to a single URI.
+ Threads borrow connections from the pool, use them, and then return them back to the pool. Since these returned
+ connections are already active / established, they can be used immediately without going through the lengthy connection
+ establishment process. This can very significantly increase the performance of systems that make many simultaneous
+ outgoing API calls.
 
-        1. allCreatedConnections    all connections created by connection makers are added to this set
-        2. allKnownConnections:     the set of all connections tracked by the connection pool
-        3. Borrowable:              connection that can be borrowed from
-        4. Borrowed:                connections that have borrowed tokens
-        5. notBorrowedExpired:      connections that have no borrowed tokens -- only these can be closed by the pool
-*/
+ Internally, SimpleURIConnectionPool organizes connections into 4 (possibly overlapping) sets:
+
+ 1. allCreatedConnections    all connections created by connection makers are added to this set
+ 2. trackedConnections:      the set of all connections tracked by the connection pool
+ 3. Borrowable:              connection that can be borrowed from
+ 4. Borrowed:                connections that have borrowed tokens
+ 5. notBorrowedExpired:      connections that have no borrowed tokens -- only these can be closed by the pool
+ */
 public final class SimpleURIConnectionPool {
     private static final Logger logger = LoggerFactory.getLogger(SimpleURIConnectionPool.class);
     private final SimpleConnectionMaker connectionMaker;
@@ -50,7 +56,7 @@ public final class SimpleURIConnectionPool {
     /** The set of all connections created by the SimpleConnectionMaker for this uri */
     private final Set<SimpleConnection> allCreatedConnections = ConcurrentHashMap.newKeySet();
     /** The set containing all connections known to this connection pool (It is not considered a state set) */
-    private final Set<SimpleConnectionState> allKnownConnections = new HashSet<>();
+    private final Set<SimpleConnectionState> trackedConnections = new HashSet<>();
     /**
      * State Sets
      * The existence or non-existence of a connection in one of these sets means that the connection is or is not in
@@ -59,6 +65,14 @@ public final class SimpleURIConnectionPool {
     private final Set<SimpleConnectionState> borrowed = new HashSet<>();
     private final Set<SimpleConnectionState> notBorrowedExpired = new HashSet<>();
 
+    /***
+     * Creates a new SimpleURIConnectionPool
+     *
+     * @param uri the URI that this connection pool creates connections to
+     * @param expireTime the length of time in milliseconds a connection is eligible to be borrowed
+     * @param poolSize the maximum number of unexpired connections the pool can hold at a given time
+     * @param connectionMaker a class that SimpleConnectionPool uses to create new connections
+     */
     public SimpleURIConnectionPool(URI uri, long expireTime, int poolSize, SimpleConnectionMaker connectionMaker) {
         EXPIRY_TIME = expireTime;
         this.uri = uri;
@@ -67,33 +81,42 @@ public final class SimpleURIConnectionPool {
     }
 
     /***
+     * Returns a network connection to a URI
      *
-     * @param createConnectionTimeout
-     * @param isHttp2
-     * @return
-     * @throws RuntimeException
+     * @param createConnectionTimeout The maximum time in seconds to wait for a new connection to be established
+     * @param isHttp2 if true, SimpleURIConnectionPool will attempt to establish an HTTP/2 connection, otherwise it will
+     *          attempt to create an HTTP/1.1 connection
+     * @return a ConnectionToken object that contains the borrowed connection. The thread using the connection must
+     *          return this connection to the pool when it is done with it by calling the borrow() method with the
+     *          ConnectionToken as the argument
+     * @throws RuntimeException if connection creation takes longer than <code>createConnectionTimeout</code> seconds,
+     *          or other issues that prevent connection creation
      */
     public synchronized SimpleConnectionState.ConnectionToken borrow(long createConnectionTimeout, boolean isHttp2) throws RuntimeException {
         long now = System.currentTimeMillis();
-        final SimpleConnectionState holder;
+        final SimpleConnectionState connectionState;
 
-        readAllConnectionHolders(now);
+        // update the connection pool's state
+        applyAllConnectionStates(now);
 
         if(borrowable.size() > 0) {
-            holder = borrowable.toArray(new SimpleConnectionState[0])[ThreadLocalRandom.current().nextInt(borrowable.size())];
+            connectionState = borrowable.toArray(new SimpleConnectionState[0])[ThreadLocalRandom.current().nextInt(borrowable.size())];
         } else {
-            if (allKnownConnections.size() < poolSize) {
-                holder = new SimpleConnectionState(EXPIRY_TIME, createConnectionTimeout, isHttp2, uri, allCreatedConnections, connectionMaker);
-                allKnownConnections.add(holder);
-            } else
+            if (trackedConnections.size() < poolSize) {
+                connectionState = new SimpleConnectionState(EXPIRY_TIME, createConnectionTimeout, isHttp2, uri, allCreatedConnections, connectionMaker);
+                trackedConnections.add(connectionState);
+            } else {
+                findAndCloseLeakedConnections();
                 throw new RuntimeException("An attempt was made to exceed the maximum size was of the " + uri.toString() + " connection pool");
+            }
         }
 
-        SimpleConnectionState.ConnectionToken connectionToken = holder.borrow(createConnectionTimeout, now);
-        readConnectionHolder(holder, now, () -> allKnownConnections.remove(holder));
+        SimpleConnectionState.ConnectionToken connectionToken = connectionState.borrow(createConnectionTimeout, now);
+        applyConnectionState(connectionState, now, () -> trackedConnections.remove(connectionState));
 
         logger.debug(showConnections("borrow"));
 
+        findAndCloseLeakedConnections();
         return connectionToken;
     }
 
@@ -110,11 +133,14 @@ public final class SimpleURIConnectionPool {
         if(connectionToken == null)
             return;
 
-        SimpleConnectionState holder = connectionToken.holder();
+        SimpleConnectionState connectionState = connectionToken.state();
         long now = System.currentTimeMillis();
 
-        holder.restore(connectionToken);
-        readAllConnectionHolders(now);
+        // update this connection's state
+        connectionState.restore(connectionToken);
+
+        // update the connection pool's state
+        applyAllConnectionStates(now);
 
         logger.debug(showConnections("restore"));
     }
@@ -127,51 +153,27 @@ public final class SimpleURIConnectionPool {
      *     This method is private, and is only called either directly or transitively by synchronized
      *     methods in this class.
      *
-     * Note:
-     *     'knownConnectionHolders::remove' is just Java syntactic sugar for '() -> knownConnectionHolders.remove()'
-     *
-     * @param now the current time in ms
+     * @param now the Unix Epoch time in milliseconds at which to evaluate the connection states
      */
-    private void readAllConnectionHolders(long now)
+    private void applyAllConnectionStates(long now)
     {
         /**
-         * Sweep all known connections and update sets
-         *
-         * Remove any connections that have unexpectedly closed
-         * Move all remaining connections to appropriate sets based on their properties
+         * Sweep all known connections and apply their state changes to the connection pool's state. Also, close
+         * any unborrowed expired connections
          */
-        final Iterator<SimpleConnectionState> knownConnectionHolders = allKnownConnections.iterator();
-        while (knownConnectionHolders.hasNext()) {
-            SimpleConnectionState connection = knownConnectionHolders.next();
-
-            // remove connections that have unexpectedly closed
-            if (connection.closed()) {
-                logger.debug("[{}: CLOSED]: Connection unexpectedly closed - Removing from known-connections set", port(connection.connection()));
-                readConnectionHolder(connection, now, knownConnectionHolders::remove);
-            }
-            // else, move connections to correct sets
-            else {
-                readConnectionHolder(connection, now, knownConnectionHolders::remove);
-
-                // close and remove connections if they are in a closeable set
-                if (notBorrowedExpired.contains(connection)) {
-                    connection.safeClose(now);
-                    readConnectionHolder(connection, now, knownConnectionHolders::remove);
-                }
-            }
-        }
-
-        // find and close any leaked connections
-        findAndCloseLeakedConnections();
+        final Iterator<SimpleConnectionState> trackedConnectionStates = trackedConnections.iterator();
+        while (trackedConnectionStates.hasNext())
+            applyConnectionState(trackedConnectionStates.next(), now, () -> trackedConnectionStates.remove());
     }
 
-    private interface RemoveFromAllKnownConnections { void remove(); }
+    @FunctionalInterface private interface RemoveFromTrackedConnections { void remove(); }
     /***
      * This method reads a connection and moves it to the correct sets based on its properties.
-     * It will also remove a connection from all sets (i.e.: stop tracking the connection) if it is closed.
+     * It will remove a connection from all sets (i.e.: stop tracking the connection) if it is closed.
+     * It will close unborrowed expired connections.
      *
      * NOTE: Closing connections and modifying sets
-     *     readConnectionHolder() and findAndCloseLeakedConnections() are the only two methods that close connections
+     *     readConnectionState() and findAndCloseLeakedConnections() are the only two methods that close connections
      *     and modify sets. This can be helpful to know for debugging since the sets comprise the entirety of the
      *     mutable state of this SimpleURIConnectionPool objects
      *
@@ -179,12 +181,12 @@ public final class SimpleURIConnectionPool {
      *     This method is private, and is only called either directly or transitively by synchronized
      *     methods in this class.
      *
-     * @param connection
-     * @param now
-     * @param knownConnections a lambda expression to remove a closed-connection from allKnownConnections, either using
-     *                         an Iterator of allKnownConnections, or directly using allKnownConnections.remove()
+     * @param connection the connection to read and move to the appropriate sets
+     * @param now the Unix Epoch time in milliseconds at which to evaluate the connection's state
+     * @param trackedConnectionRemover a lambda expression to remove a closed-connection from trackedConnections, either using
+     *                                 an Iterator of trackedConnections, or directly using trackedConnections.remove()
      */
-    private void readConnectionHolder(SimpleConnectionState connection, long now, RemoveFromAllKnownConnections knownConnections) {
+    private void applyConnectionState(SimpleConnectionState connection, long now, RemoveFromTrackedConnections trackedConnectionRemover) {
 
         /**
          * Remove all references to closed connections
@@ -193,14 +195,9 @@ public final class SimpleURIConnectionPool {
          * (and will therefore be garbage collected)
          */
         if(connection.closed()) {
-            logger.debug("[{}: CLOSED]: Connection closed - Stopping connection tracking", port(connection.connection()));
+            logger.debug("[{}: CLOSED]: Connection unexpectedly closed - Stopping connection tracking", port(connection.connection()));
 
-            allCreatedConnections.remove(connection.connection());  // connection.connection() returns a SimpleConnection
-            knownConnections.remove();  // this will remove the connection from allKnownConnections directly, or via Iterator
-
-            borrowable.remove(connection);
-            borrowed.remove(connection);
-            notBorrowedExpired.remove(connection);
+            removeFromConnectionTracking(connection, trackedConnectionRemover);
             return;
         }
 
@@ -213,25 +210,51 @@ public final class SimpleURIConnectionPool {
         updateSet(borrowable, isBorrowable, connection);
         updateSet(borrowed, isBorrowed, connection);
         updateSet(notBorrowedExpired, isNotBorrowedExpired, connection);
+
+        // close and remove connection if it is in a closeable set
+        if (notBorrowedExpired.contains(connection))
+        {
+            connection.safeClose(now);
+            removeFromConnectionTracking(connection, trackedConnectionRemover);
+
+            logger.debug("[{}: CLOSED]: Expired connection was closed - Connection tracking stopped", port(connection.connection()));
+        }
     }
 
     /***
-     * Takes a Set, a boolean, and a connectionHolder
-     * If the boolean is true, it will add the connectionHolder to the Set, otherwise, it will remove it from the Set
+     * Removes a connection (and its connection state) from being tracked by the pool
+     *
+     * @param connection the connection state (and connection) to remove from connection tracking
+     * @param trackedConnectionRemover a lamda expression to remove the state that depends on whether it is removed in
+     *          an <code>Iterator</code> loop or directly from the trackedConnections <code>Set</code>
+     */
+    private void removeFromConnectionTracking(SimpleConnectionState connection, RemoveFromTrackedConnections trackedConnectionRemover)
+    {
+        allCreatedConnections.remove(connection.connection());  // connection.connection() returns a SimpleConnection
+        trackedConnectionRemover.remove();  // this will remove the connection from trackedConnections directly, or via Iterator
+
+        borrowable.remove(connection);
+        borrowed.remove(connection);
+        notBorrowedExpired.remove(connection);
+    }
+
+    /***
+     * Takes a Set, a boolean, and a connectionState
+     * If the boolean is true, it will add the connectionState to the Set, otherwise, it will remove it from the Set
      *
      * NOTE: Thread Safety
      *     This method is private, and is only called either directly or transitively by synchronized
      *     methods in this class.
      *
-     * @param set the set to potentially add or remove the connectionHolder from
-     * @param isMember if true, it will add connectionHolder to set, otherwise, it will remove connectionHolder from set
-     * @param connectionHolder the connectionHolder to add or remove from the set
+     * @param set the set to potentially add or remove the connectionState from
+     * @param isMember if true, it will add connectionState to set, otherwise, it will remove connectionState from set
+     * @param connectionState the connectionState to add or remove from the set
      */
-    private void updateSet(Set<SimpleConnectionState> set, boolean isMember, SimpleConnectionState connectionHolder) {
+    private void updateSet(Set<SimpleConnectionState> set, boolean isMember, SimpleConnectionState connectionState) {
         if(isMember)
-            set.add(connectionHolder);
+            set.add(connectionState);
         else
-            set.remove(connectionHolder);
+            set.remove(connectionState);
     }
 
     /**
@@ -245,19 +268,19 @@ public final class SimpleURIConnectionPool {
      *     2) the raw connection unexpectedly closes during the creation of its SimpleConnectionState
      *
      * NOTE: Closing connection and modifying sets
-     *     readConnectionHolder() and findAndCloseLeakedConnections() are the only two methods that close connections
+     *     readConnectionState() and findAndCloseLeakedConnections() are the only two methods that close connections
      *     and modify sets. This can be helpful to know for debugging since the sets comprise the entirety of the
      *     mutable state of this SimpleURIConnectionPool objects
      */
     private void findAndCloseLeakedConnections()
     {
         // remove all connections that the connection pool is tracking, from the set of all created connections
-        for(SimpleConnectionState knownConnection: allKnownConnections)
-            allCreatedConnections.remove(knownConnection.connection());
+        for(SimpleConnectionState trackedConnection: trackedConnections)
+            allCreatedConnections.remove(trackedConnection.connection());
 
         // any remaining connections are leaks, and can now be safely closed
         if(allCreatedConnections.size() > 0) {
-            logger.debug("{} untracked connection found", allCreatedConnections.size());
+            logger.debug("{} untracked connection(s) found", allCreatedConnections.size());
 
             Iterator<SimpleConnection> leakedConnections = allCreatedConnections.iterator();
             while(leakedConnections.hasNext()) {
@@ -284,14 +307,14 @@ public final class SimpleURIConnectionPool {
      *
      * NOTE: Iteration Safety
      *     This method should not be used inside loops that iterate through elements of borrowable, borrowed,
-     *     notBorrowedExpired, or allKnownConnections sets
+     *     notBorrowedExpired, or trackedConnections sets
      */
     private String showConnections(String transitionName) {
         return "After " + transitionName + " - " +
                 showConnections("BORROWABLE", borrowable) +
                 showConnections("BORROWED", borrowed) +
                 showConnections("NOT_BORROWED_EXPIRED", notBorrowedExpired) +
-                showConnections("TRACKED", allKnownConnections);
+                showConnections("TRACKED", trackedConnections);
     }
 
     /***
@@ -308,8 +331,8 @@ public final class SimpleURIConnectionPool {
             sb.append("0");
         else {
             int numCons = set.size();
-            for (SimpleConnectionState holder : set) {
-                sb.append(port(holder.connection()));
+            for (SimpleConnectionState state : set) {
+                sb.append(port(state.connection()));
                 if (--numCons > 0) sb.append(" ");
             }
         }

--- a/client/src/main/java/com/networknt/client/simplepool/mock/TestConnectionMaker.java
+++ b/client/src/main/java/com/networknt/client/simplepool/mock/TestConnectionMaker.java
@@ -38,18 +38,9 @@ public class TestConnectionMaker implements SimpleConnectionMaker {
 
     @Override
     public SimpleConnection makeConnection(long createConnectionTimeout, boolean isHttp2, URI uri, Set<SimpleConnection> allConnections)
-        throws RuntimeException
+            throws RuntimeException
     {
         SimpleConnection connection = instantiateConnection(createConnectionTimeout, isHttp2, allConnections);
-        return connection;
-    }
-
-    @Override
-    public SimpleConnection reuseConnection(long createConnectionTimeout, SimpleConnection connection) throws RuntimeException {
-        if(connection == null)
-            return null;
-        if(!connection.isOpen())
-            throw new RuntimeException("Reused-connection has been unexpectedly closed");
         return connection;
     }
 

--- a/client/src/main/java/com/networknt/client/simplepool/mock/TestRunner.java
+++ b/client/src/main/java/com/networknt/client/simplepool/mock/TestRunner.java
@@ -19,7 +19,7 @@
  */
 package com.networknt.client.simplepool.mock;
 
-import com.networknt.client.simplepool.SimpleConnectionHolder;
+import com.networknt.client.simplepool.SimpleConnectionState;
 import com.networknt.client.simplepool.SimpleConnectionMaker;
 import com.networknt.client.simplepool.SimpleURIConnectionPool;
 import org.slf4j.Logger;
@@ -176,7 +176,7 @@ public class TestRunner
         public void run() {
             logger.debug("{} Starting", Thread.currentThread().getName());
             while(!stopped.get()) {
-                SimpleConnectionHolder.ConnectionToken connectionToken = null;
+                SimpleConnectionState.ConnectionToken connectionToken = null;
                 try {
                     logger.debug("{} Borrowing connection", Thread.currentThread().getName());
                     connectionToken = pool.borrow(createConnectionTimeout, isHttp2);

--- a/client/src/main/java/com/networknt/client/simplepool/mock/TestRunner.java
+++ b/client/src/main/java/com/networknt/client/simplepool/mock/TestRunner.java
@@ -49,8 +49,8 @@ public class TestRunner
     private long createConnectionTimeout = 5; // in seconds
     private long borrowTime = 3;              // in seconds
     private long borrowJitter = 4;            // in seconds
-    private long reconnectTime = 2;           // in seconds
-    private long reconnectTimeJitter = 2;     // in seconds
+    private long reborrowTime = 2;           // in seconds
+    private long reborrowTimeJitter = 2;     // in seconds
     private int threadStartJitter = 3;        // in seconds
     private boolean isHttp2 = true;
 
@@ -110,14 +110,14 @@ public class TestRunner
     }
 
     /** Amount of time in seconds that borrower threads waits after returning a connection to borrow again. Default 2s */
-    public TestRunner setWaitTimeBeforeReborrow(long reconnectTime) {
-        this.reconnectTime = reconnectTime;
+    public TestRunner setWaitTimeBeforeReborrow(long reborrowTime) {
+        this.reborrowTime = reborrowTime;
         return this;
     }
 
     /** Max random additional time in seconds that borrower threads waits after returning a connection to borrow again. Default 2s */
-    public TestRunner setWaitTimeBeforeReborrowJitter(long reconnectTimeJitter) {
-        this.reconnectTimeJitter = reconnectTimeJitter;
+    public TestRunner setWaitTimeBeforeReborrowJitter(long reborrowTimeJitter) {
+        this.reborrowTimeJitter = reborrowTimeJitter;
         return this;
     }
 
@@ -149,7 +149,7 @@ public class TestRunner
 
             logger.debug("> Creating and starting threads...");
             createAndStartCallers(
-                    numCallers, threadStartJitter, pool, stopped, createConnectionTimeout, isHttp2, borrowTime, borrowJitter, reconnectTime, reconnectTimeJitter, latch);
+                    numCallers, threadStartJitter, pool, stopped, createConnectionTimeout, isHttp2, borrowTime, borrowJitter, reborrowTime, reborrowTimeJitter, latch);
             logger.debug("> All threads created and started");
 
             logger.debug("> SLEEP for {} seconds", testLength);
@@ -177,13 +177,13 @@ public class TestRunner
             boolean isHttp2,
             long borrowTime,
             long borrowJitter,
-            long reconnectTime,
-            long reconnectTimeJitter,
+            long reborrowTime,
+            long reborrowTimeJitter,
             CountDownLatch latch) throws InterruptedException
     {
         while(numCallers-- > 0) {
             new CallerThread(
-                pool, stopped, createConnectionTimeout, isHttp2, borrowTime, borrowJitter, reconnectTime, reconnectTimeJitter, latch).start();
+                pool, stopped, createConnectionTimeout, isHttp2, borrowTime, borrowJitter, reborrowTime, reborrowTimeJitter, latch).start();
             if(threadStartJitter > 0)
                 Thread.sleep(ThreadLocalRandom.current().nextLong(threadStartJitter+1) * 1000);
         }
@@ -198,8 +198,8 @@ public class TestRunner
         private final boolean isHttp2;
         private final long borrowTime;
         private final long borrowJitter;
-        private final long reconnectTime;
-        private final long reconnectTimeJitter;
+        private final long reborrowTime;
+        private final long reborrowTimeJitter;
 
         public CallerThread(
             SimpleURIConnectionPool pool,
@@ -208,8 +208,8 @@ public class TestRunner
             boolean isHttp2,
             long borrowTime,
             long borrowJitter,
-            long reconnectTime,
-            long reconnectTimeJitter,
+            long reborrowTime,
+            long reborrowTimeJitter,
             CountDownLatch latch)
         {
             this.latch = latch;
@@ -219,8 +219,8 @@ public class TestRunner
             this.isHttp2 = isHttp2;
             this.borrowTime = borrowTime;
             this.borrowJitter = borrowJitter;
-            this.reconnectTime = reconnectTime;
-            this.reconnectTimeJitter = reconnectTimeJitter;
+            this.reborrowTime = reborrowTime;
+            this.reborrowTimeJitter = reborrowTimeJitter;
         }
 
         @Override
@@ -242,7 +242,7 @@ public class TestRunner
                     logger.debug("{} Returning connection", Thread.currentThread().getName());
                     pool.restore(connectionToken);
 
-                    reborrowWaitTime(reconnectTime, reconnectTimeJitter);
+                    reborrowWaitTime(reborrowTime, reborrowTimeJitter);
                 }
             }
             latch.countDown();
@@ -253,8 +253,8 @@ public class TestRunner
             wait("{} Borrowing connection for {} seconds...", borrowTime, borrowJitter);
         }
 
-        private void reborrowWaitTime(long reconnectTime, long reconnectTimeJitter) {
-            wait("{} Waiting for {} seconds to borrow connection again...", borrowTime, borrowJitter);
+        private void reborrowWaitTime(long reborrowTime, long reborrowTimeJitter) {
+            wait("{} Waiting for {} seconds to borrow connection again...", reborrowTime, reborrowTimeJitter);
         }
 
         private void wait(String logMessage, long waitTime, long waitTimeJitter) {

--- a/client/src/main/java/com/networknt/client/simplepool/undertow/SimpleUndertowConnection.java
+++ b/client/src/main/java/com/networknt/client/simplepool/undertow/SimpleUndertowConnection.java
@@ -23,10 +23,10 @@ import com.networknt.client.simplepool.SimpleConnection;
 import io.undertow.client.ClientConnection;
 import org.xnio.IoUtils;
 
-public class SimpleClientConnection implements SimpleConnection {
+public class SimpleUndertowConnection implements SimpleConnection {
     private ClientConnection connection;
 
-    public SimpleClientConnection(ClientConnection connection) {
+    public SimpleUndertowConnection(ClientConnection connection) {
         this.connection = connection;
     }
 

--- a/client/src/main/java/com/networknt/client/simplepool/undertow/SimpleUndertowConnectionMaker.java
+++ b/client/src/main/java/com/networknt/client/simplepool/undertow/SimpleUndertowConnectionMaker.java
@@ -70,7 +70,7 @@ public class SimpleUndertowConnectionMaker implements SimpleConnectionMaker
         ClientCallback<ClientConnection> connectionCallback = new ClientCallback<ClientConnection>() {
             @Override
             public void completed(ClientConnection connection) {
-                logger.debug("New connection {} established with {}", port(connection), uri);
+                if(logger.isDebugEnabled()) logger.debug("New connection {} established with {}", port(connection), uri);
                 SimpleConnection simpleConnection = new SimpleUndertowConnection(connection);
 
                 // note: its vital that allCreatedConnections and result contain the same SimpleConnection reference
@@ -80,7 +80,7 @@ public class SimpleUndertowConnectionMaker implements SimpleConnectionMaker
 
             @Override
             public void failed(IOException e) {
-                logger.debug("Failed to establish new connection for uri: {}", uri);
+                if(logger.isDebugEnabled()) logger.debug("Failed to establish new connection for uri: {}", uri);
                 result.setException(e);
             }
         };

--- a/client/src/main/java/com/networknt/client/simplepool/undertow/SimpleUndertowConnectionMaker.java
+++ b/client/src/main/java/com/networknt/client/simplepool/undertow/SimpleUndertowConnectionMaker.java
@@ -41,16 +41,16 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class SimpleClientConnectionMaker implements SimpleConnectionMaker
+public class SimpleUndertowConnectionMaker implements SimpleConnectionMaker
 {
-    private static final Logger logger = LoggerFactory.getLogger(SimpleClientConnectionMaker.class);
+    private static final Logger logger = LoggerFactory.getLogger(SimpleUndertowConnectionMaker.class);
     private static final ByteBufferPool BUFFER_POOL = new DefaultByteBufferPool(true, ClientConfig.get().getBufferSize() * 1024);
-    private static SimpleClientConnectionMaker simpleClientConnectionMaker = null;
+    private static SimpleUndertowConnectionMaker simpleUndertowConnectionMaker = null;
 
     public static SimpleConnectionMaker instance() {
-        if(simpleClientConnectionMaker == null)
-            simpleClientConnectionMaker = new SimpleClientConnectionMaker();
-        return simpleClientConnectionMaker;
+        if(simpleUndertowConnectionMaker == null)
+            simpleUndertowConnectionMaker = new SimpleUndertowConnectionMaker();
+        return simpleUndertowConnectionMaker;
     }
 
     @Override
@@ -71,7 +71,7 @@ public class SimpleClientConnectionMaker implements SimpleConnectionMaker
             @Override
             public void completed(ClientConnection connection) {
                 logger.debug("New connection {} established with {}", port(connection), uri);
-                SimpleConnection simpleConnection = new SimpleClientConnection(connection);
+                SimpleConnection simpleConnection = new SimpleUndertowConnection(connection);
 
                 // note: its vital that allCreatedConnections and result contain the same SimpleConnection reference
                 allCreatedConnections.add(simpleConnection);

--- a/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
+++ b/consul/src/main/java/com/networknt/consul/client/ConsulClientImpl.java
@@ -19,11 +19,11 @@ package com.networknt.consul.client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.networknt.client.ClientConfig;
 import com.networknt.client.Http2Client;
+import com.networknt.client.simplepool.SimpleConnectionState;
 import com.networknt.config.Config;
 import com.networknt.consul.*;
 import com.networknt.httpstring.HttpStringConstants;
 import com.networknt.utility.StringUtils;
-import io.undertow.UndertowOptions;
 import io.undertow.client.ClientConnection;
 import io.undertow.client.ClientRequest;
 import io.undertow.client.ClientResponse;
@@ -33,7 +33,6 @@ import io.undertow.util.Methods;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnio.IoUtils;
-import org.xnio.OptionMap;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -46,10 +45,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 // use SimpleURIConnectionPool as the connection pool
 import com.networknt.client.simplepool.SimpleURIConnectionPool;
-import com.networknt.client.simplepool.SimpleConnectionHolder;
 // Use Undertow ClientConnection as raw connection
 import com.networknt.client.simplepool.SimpleConnectionMaker;
-import com.networknt.client.simplepool.undertow.SimpleClientConnectionMaker;
+import com.networknt.client.simplepool.undertow.SimpleUndertowConnectionMaker;
 
 /**
  * A client that talks to Consul agent with REST API.
@@ -90,7 +88,7 @@ public class ConsulClientImpl implements ConsulClient {
 		}
 
 		// create SimpleURIConnection pool
-		SimpleConnectionMaker undertowConnectionMaker = SimpleClientConnectionMaker.instance();
+		SimpleConnectionMaker undertowConnectionMaker = SimpleUndertowConnectionMaker.instance();
 		pool = new SimpleURIConnectionPool(
 				uri, ClientConfig.get().getConnectionExpireTime(), ClientConfig.get().getConnectionPoolSize(), undertowConnectionMaker);
 	}
@@ -100,7 +98,7 @@ public class ConsulClientImpl implements ConsulClient {
 		logger.trace("checkPass serviceId = {}", serviceId);
 		String path = "/v1/agent/check/pass/" + "check-" + serviceId;
 		ClientConnection connection = null;
-		SimpleConnectionHolder.ConnectionToken connectionToken = null;
+		SimpleConnectionState.ConnectionToken connectionToken = null;
 
 		try {
 			logger.debug("Getting connection from pool with {}", uri);
@@ -125,7 +123,7 @@ public class ConsulClientImpl implements ConsulClient {
 		logger.trace("checkFail serviceId = {}", serviceId);
 		String path = "/v1/agent/check/fail/" + "check-" + serviceId;
 		ClientConnection connection = null;
-		SimpleConnectionHolder.ConnectionToken connectionToken = null;
+		SimpleConnectionState.ConnectionToken connectionToken = null;
 
 		try {
 			logger.debug("Getting connection from pool with {}", uri);
@@ -149,7 +147,7 @@ public class ConsulClientImpl implements ConsulClient {
 		String json = service.toString();
 		String path = "/v1/agent/service/register";
 		ClientConnection connection = null;
-		SimpleConnectionHolder.ConnectionToken connectionToken = null;
+		SimpleConnectionState.ConnectionToken connectionToken = null;
 
 		try {
 			logger.debug("Getting connection from pool with {}", uri);
@@ -173,7 +171,7 @@ public class ConsulClientImpl implements ConsulClient {
 	public void unregisterService(String serviceId, String token) {
 		String path = "/v1/agent/service/deregister/" + serviceId;
 		ClientConnection connection = null;
-		SimpleConnectionHolder.ConnectionToken connectionToken = null;
+		SimpleConnectionState.ConnectionToken connectionToken = null;
 
 		try {
 			logger.debug("Getting connection from pool with {}", uri);
@@ -226,7 +224,7 @@ public class ConsulClientImpl implements ConsulClient {
 		}
 		logger.trace("Consul health service path = {}", path);
 
-		SimpleConnectionHolder.ConnectionToken connectionToken = null;
+		SimpleConnectionState.ConnectionToken connectionToken = null;
 		try {
 			logger.debug("Getting connection from pool with {}", uri);
 			// this will throw a Runtime Exception if creation of Consul connection fails


### PR DESCRIPTION
# SimpleConnectionPool v2
`SimpleConnectionPool` is a simple, natively mockable, threadsafe, resilient, high-performance connection pool intended to replace `com.networknt.client.http.Http2ClientConnectionPool`.

Use of this connection pool fully resolves issue 1656 (https://github.com/networknt/light-4j/issues/1656) by replacing the use of `Http2ClientConnection` in `com.networknt.consul.client.ConsulClientImpl.lookupHealthService()` with `SimpleURIConnectionPool`.

## Breaking Changes
  * class `SimpleConnectionHolder` renamed to `SimpleConnectionState`
  * class `SimpleClientConnection` renamed to `SimpleUndertowConnection`
  * class `SimpleClientConnectionMaker` renamed to `SimpleUndertowConnectionMaker`
  * method `reuseConnection()` removed from the `SimpleConnectionMaker` interface

*See issue https://github.com/networknt/light-4j/issues/1905 for more details on changes.*

## Focus on Stability and Testability
The primary goal of SimpleConnectionPool is operational stability and reliability. Optimizations were considered only after stability and resilience were confirmed.

Easy testability was vital to confirm the correct behaviour of the connection pool under a wide array of common and corner-case conditions. To this end, the connection pool was developed with mockability built-in.

## Avoidance of Consul Connection Bug

The following Consul connection-leak bug was reported in August 2020, but has yet to be resolved.

> When a Consul client cancels a blocking HTTP-query, the TCP connection is not closed correctly by the server. The TCP connection stays in the FIN_WAIT-2 state until it's tcp_fin_timeout expires. The FIN_WAIT-2 means that the client is waiting for an ACK from the server.
> 
> When a lot of blocking queries are cancelled and retried at the same time, the servers http_max_conns_per_client can be hit the further client queries will fail.

> Bug Ticket URL: https://github.com/hashicorp/consul/issues/8524

SimpleConnectionPool avoids this bug entirely by never closing connections that are in use. While this can cause connection expiry times to not be precisely honoured, it also ensures that Consul blocking queries are never canceled before they complete, thereby avoiding the conditions that manifest this bug.

## Multi-Layer Architecture
The connection pool was developed using a multilayer architecure.

### Level 1: SimpleConnectionPool routes requests to URI connection pools
Threads that need a connection to a URI must 'borrow' a connection from the pool and then `restore` that connection to the pool when they are done with it.

A `SimpleConnectionPool` routes these URI-connection requests to a `SimpleURIConnectionPool` for that URI. If a `SimpleURIConnectionPool` does not exist for that URI, the `SimpleConnectionPool` will create one.

The `SimpleConnectionPool` needs only minimal thread synchronization since the `SimpleURIConnectionPool`s are already fully thread safe. A benefit of this, is increased opportunity for concurrency. For example: N threads can request connections to N distinct URIs concurrently.

### Level 2: SimpleURIConnectionPools manage connections to a single URI
A `SimpleURIConnectionPool` manages connections to a single URI where the connections it manages have the ability to be used by 1 or more threads concurrently. A `SimpleURIConnectionPool`:

- Enforces a configurable maximum number of connections
- Closes connections after a configurable 'expiry' time, but ensures that it never closes connections that are in use
- Safely manages connection resources (if client behaves as expected)
- Safely closes leaked connections that may be created by connection-creation callback threads after a connection-creation timeout has occurred in the parent thread (more on this below)
- Is threadsafe

Also, note that `SimpleURIConnectionPool`s can be used used independently of `SimpleConnectionPool`. This means that, any code that only needs to connect to a single URI can use a `SimpleURIConnectionPool` directly--it does not need to make requests to borrow connections from a `SimpleConnectionPool` (which is only needed for code that needs to connect to multiple distinct URIs).

The `SimpleURIConnectionPool` needs very little information about connections to manage the pool. It only needs to know if the connection is:

- **borrowed**
- **borrowable**
- **expired**
- **closed**

Note: More than one of these properties can simultaneously apply to a connection (e.g.: an HTTP/2 connection may be both **borrowed** and **borrowable**).

### Level 3: SimpleConnectionStates manage connection states

`SimpleConnectionState` objects both create and manage the state of a single network connection.

`SimpleConnectionState`s have a 1-1 relationship with their connection. In other words:

- every connection in the pool is created by -- and contained in -- a single `SimpleConnectionState`, and
- every `SimpleConnectionState` contains the single connection it created.

When a `SimpleURIConnectionPool` needs a new connection, it will create a new `SimpleConnectionState` object. The connection pool will then manage that connection exclusively by communicating through the connection's enclosing `SimpleConnectionState`, rather than managing the connection directly.

The `SimpleConnectionState` provides the following information about a connection to the pool:

- **borrowed**
  - A connection is considered 'borrowed' if 1 or more threads are currently using the connection at the moment.
- **borrowable**
  - A connection is considered 'borrowable' if the connection can be used by a new thread
    - _HTTP/1.1_: HTTP/1.1 connections are only borrowable when 0 connection tokens are currently borrowed
    - _HTTP/2_: HTTP/2 connections are  always be borrowable
- **expired** / **valid**
  - A connection is 'expired' once its age exceeds the pool's connection expiry time setting
  - A connection is 'valid' if it is not yet expired
- **closed**
  - A connection is closed if the the pool or the OS closes it

The state diagram of a `SimpleConnectionState` is shown below.

#### SimpleConnectionState - State diagram for a connection
 <pre>
              |
             \/
    [ NOT_BORROWED_VALID ]  --(borrow)--&gt;  [ BORROWED_VALID ]
              |             &lt;-(restore)--          |
              |                                    |
           (expire)                             (expire)
              |                                    |
             \/                                   \/
    [ NOT_BORROWED_EXPIRED ] &lt;-(restore)-- [ BORROWED_EXPIRED ]
             |
          (close) (*)
             |
            \/
        [ CLOSED ]
 </pre>

> (*) ***NOTE***<br/>
> A connection can be closed explicitly by the connection pool, or it can be unexpectedly closed at any time by the OS. If it is closed unexpectedly by the OS, then the state can jump directly to CLOSED regardless of what state it is currently in.

### Level 4: SimpleConnections and SimpleConnectionMakers

`SimpleConnection` interfaces wrap physical 'raw' network connections. For example, the `SimpleUndertowConnection` class implements `SimpleConnection` and wraps Undertow's `ClientConnection`.

`SimpleConnectionMaker`'s are factories that create `SimpleConnection` objects, and are used by `SimpleConnectionState` objects to create the connection they manage. Different implementations of `SimpleConnectionMaker` can be used to create different types of raw connections. For example: A `SimpleUndertowConnectionMaker` uses the Undertow networking library to create connections, a `SimpleApacheConnectionMaker` could use the Apache libraries, and a `SimpleMockConnectionMaker` could create mock connections used for testing.

_Note:_ `SimpleConnectionState`s only deal with `SimpleConnection` objects -- they never deal directly with 'raw' connections (such as Undertow's `ClientConnection` objects).

#### Creating a new network (raw) connection
1. Create a `SimpleConnectionMaker` (e.g.: a `SimpleUndertowConnectionMaker`)
<pre>
[Connection Pool]   [Connection State]   [Connection Maker]   [Simple Connection]   [Raw Connection]
       [|]                   |                    |                    |                    |
       [|]   &lt;&lt; creates &gt;&gt;   |                    |                    |                    |
       [|]-------------------------------------->[|]                   |                    |
       [|]                   |                   [|]                   |                    |
</pre>
<br/>

2. Pool creates new connections by instantiating new `SimpleConnectState` objects (passing them a `SimpleConnectionMaker` in their constructor)
3. `SimpleConnectionState` uses the `SimpleConnectionMaker` to create `SimpleConnection` objects that wrap raw network connections
<pre>
[Connection Pool]   [Connection State]   [Connection Maker]   [Simple Connection]   [Raw Connection]
       [|]                   |                   [|]                   |                    |
       [|]   &lt;&lt; creates &gt;&gt;   |                   [|]                   |                    |
       [|]----------------->[|]                  [|]                   |                    |
       [|]                  [|]    &lt;&lt; uses &gt;&gt;    [|]                   |                    |
       [|]                  [|]----------------->[|]                   |                    |
       [|]                  [|]                  [|]   &lt;&lt; creates &gt;&gt;   |                    |
       [|]                  [|]                  [|]----------------->[|]                   |
       [|]                  [|]                  [|]                  [|]   &lt;&lt; creates &gt;&gt;   |
       [|]                  [|]                  [|]                  [|]----------------->[|]
</pre>

## Finding and closing leaked connections
Typically, new connections are created in a callback thread spawned by the thread that will use the connection.

### Example of connection leak detection: SimpleUndertowConnectionMaker

To create a new connection, a `SimpleUndertowConnectionMaker` will spawn a new thread to create the connection. It will then wait a configurable amount of time (a timeout) for the connection-creation thread to finish creating the connection.

#### Case 1: Connection creation failed (OK)

If the connection-creation thread is unable to create the connection, then `SimpleUndertowConnectionMaker` will throw a 'connection-creation' exception and `SimpleURIConnectionPool` will not recieve a new connection.

#### Case 2: Connection successfully created before timeout (OK)

If the connection is successfully created before the timeout expires, then `SimpleUndertowConnectionMaker` will get the new connection from the connection-creation thread and return it to `SimpleConnectionState` (and, in turn, the new `SimpleConnectionState` holding the new connection will be returned to the pool).

#### Case 3: Connection successfully created *after* timeout (!)

If the connection is successfully created ***after*** the timeout expires, then -- as in case 1 -- `SimpleUndertowConnectionMaker` will throw a 'connection-creation' exception and `SimpleURIConnectionPool` will not receive a new connection.

However, in contrast to case 2: since a new connection was successfully created but not returned to the pool, it means that this new connection will exist but be unknown to the `SimpleURIConnectionPool`. Without knowledge of the connection, `SimpleURIConnectionPool` cannot not close it and so this `untracked` connection is considered a **connection leak**.

### Handling connections created after timeouts

Case 3 results in connections that have been created by a `SimpleConnectionMaker` but are unknown to the pool and  are called 'untracked' connections (conversely, connections known to the pool are called 'tracked' connections).

To ensure that all untracked connections are closed, users of a `SimpleConnectionMaker` must pass a threadsafe `Set<SimpleConnection>` to the `SimpleConnectionMaker`'s `makeConnection()` method. Implementations of `SimpleConnectionMaker` must add all connections they create to this `Set`.

To ensure all untracked connections are closed, `SimpleURIConnectionPool` will periodically remove (but not close) all tracked connections from this set (e.g.: it will remove the connections it knows about). It will then close close any connections that remain in the set, since these remaining connections are untracked. This ensures that any untracked connections in the `Set` are safely closed. 

## Mockability
Since `SimpleConnectState` objects use a `SimpleConnectionMaker` to create their connections, and since the connections that `SimpleConnectionMakers` create implement the `SimpleConnection` interface, it means that `SimpleURIConnectionPool`, and `SimpleConnectionState` are able to manage the pool without having any knowledge of the raw connections they are managing.

This means mock connections can be created by simply implementing `SimpleConnection` and creating a `SimpleConnectionMaker` that instantiates these mock connections.

#### Mock Test Harness
SimpleConnectionPool comes with a test harness that can be used to easily test mock connections. For example, to test how the connection pool will handle a connection that randomly closes can be built as follows:

**1. Develop the mock connection**
```java
public class MockRandomlyClosingConnection implements SimpleConnection {
    private volatile boolean closed = false;
    private boolean isHttp2 = true;
    private String MOCK_ADDRESS = "MOCK_HOST_IP:" + ThreadLocalRandom.current().nextInt((int) (Math.pow(2, 15) - 1.0), (int) (Math.pow(2, 16) - 1.0));

    /***
     * This mock connection simulates a multiplexable connection that has a 5% chance of closing
     *  every time isOpen() is called
     */
    public MockRandomlyClosingConnection(boolean isHttp2) { this.isHttp2 = isHttp2; }
    @Override public boolean isOpen() {
        if(ThreadLocalRandom.current().nextInt(20) == 0)
            closed = true;
        return !closed;
    }
    @Override public Object getRawConnection() {
        throw new RuntimeException("Mock connection has no raw connection");
    }
    @Override public boolean isMultiplexingSupported() { return isHttp2; }
    @Override public String getLocalAddress() { return MOCK_ADDRESS; }
    @Override public void safeClose() { closed = true; }
}
```

**2. Test how the connection pool handles the connection**
```java
public class TestRandomlyClosingConnection {
    public static void main(String[] args) {
        new TestRunner()
            // set connection properties
            .setConnectionPoolSize(100)
            .setSimpleConnectionClass(MockRandomlyClosingConnection.class)
            .setCreateConnectionTimeout(5)
            .setConnectionExpireTime(5)
            .setHttp2(true)

            // configure borrower-thread properties
            .setNumBorrowerThreads(8)
            .setBorrowerThreadStartJitter(3)
            .setBorrowTimeLength(5)
            .setBorrowTimeLengthJitter(5)
            .setWaitTimeBeforeReborrow(2)
            .setWaitTimeBeforeReborrowJitter(2)

            // execute test
            .setTestLength(10*60)
            .executeTest();
    }
}
```

## Plugability
`SimpleConnectionPool` requires very litte information about a connection in order to manage that connection. This lends itself to supporting many different networking APIs. If one can implement a `SimpleConnection` and `SimpleConnectionMaker` using a networking API, then connections created using that API can be managed by `SimpleConnectionPool`.

`ClientConnections` created using undertow's libraries can be wrapped this way. See the `simplepool.undertow` package to see how support for undertow was implemented.

## How to safely use SimpleConnectionPool and SimpleURIConnectionPool
The following code snippet demonstrates the recommended way to structure code that borrows a connection.

*Note: The code below is the same whether <code>pool</code> is a SimpleConnectionPool or a SimpleURIConnectionPool*.

```java
SimpleConnectionState.ConnectionToken borrowToken = null;
try {
    borrowToken = pool.borrow(createConnectionTimeout, isHttp2);
    ClientConnection connection = (ClientConnection) borrowToken.getRawConnection();

    // Use connection...
    
} finally {
    // restore token
    pool.restore(borrowToken);
}    
```

...and this demonstrates the recommended way to borrow connections in a loop...

```java
while(true) {
    SimpleConnectionState.ConnectionToken borrowToken = null;
    try {
        borrowToken = pool.borrow(createConnectionTimeout, isHttp2);
        ClientConnection connection = (ClientConnection) borrowToken.getRawConnection();

        // Use connection...
        
    } finally {
        // restore token
        pool.restore(borrowToken);
    }    
}
```