### PR TITLE
Fix order dependent test in handler test

### DIFF
--- a/handler/src/main/java/com/networknt/handler/Handler.java
+++ b/handler/src/main/java/com/networknt/handler/Handler.java
@@ -540,6 +540,7 @@ public class Handler {
         Handler.configName = configName;
         config = (HandlerConfig) Config.getInstance().getJsonObjectConfig(configName, HandlerConfig.class);
         initHandlers();
+        initChains();
         initPaths();
     }
 

--- a/handler/src/test/java/com/networknt/handler/HandlerTest.java
+++ b/handler/src/test/java/com/networknt/handler/HandlerTest.java
@@ -24,6 +24,7 @@ import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.PathTemplateMatcher;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -31,6 +32,11 @@ import java.util.List;
 import java.util.Map;
 
 public class HandlerTest {
+
+    @Before()
+    public void setUp() throws Exception {
+        Handler.setConfig("handler");
+    }
 
     @Test
     public void validClassNameWithoutAt_split_returnsCorrect() throws Exception {

--- a/handler/src/test/java/com/networknt/handler/HandlerTest.java
+++ b/handler/src/test/java/com/networknt/handler/HandlerTest.java
@@ -35,6 +35,7 @@ public class HandlerTest {
 
     @Before()
     public void setUp() throws Exception {
+        // Resetting HandlerConfig to default Config before each test run
         Handler.setConfig("handler");
     }
 


### PR DESCRIPTION
#### Issue
- In `com.networknt.handler.HandlerTest`, the unit test `validConfig_init_handlersCreated()` can trigger `java.lang.RuntimeException` when being run before the unit test `invalidMethod_init_throws()` in the same class because it pollutes state shared among tests.
- It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

Fixes #2005 

#### Solution
- Resetting the `HandlerConfig` to default value before each test run using the Junit's `@Before` annotation, where the configuration is set to default value through `Handler.setConfig('handler')`
- Adding `initChain()` because `initPath()`  in `setConfig`, which expects handler or chain to already be created.