### PR TITLE
Fixes #2012 order dependent tests in `CorrelationTest`

### DIFF
--- a/correlation/src/test/java/com/networknt/correlation/CorrelationHandlerTest.java
+++ b/correlation/src/test/java/com/networknt/correlation/CorrelationHandlerTest.java
@@ -178,6 +178,10 @@ public class CorrelationHandlerTest {
         } finally {
             IoUtils.safeClose(connection);
         }
+
+        // set the autogen of the correlation ID to default value
+        CorrelationHandler.config.setAutogenCorrelationID(true);
+
         int statusCode = reference.get().getResponseCode();
         String body = reference.get().getAttachment(Http2Client.RESPONSE_BODY);
         Assert.assertEquals(200, statusCode);


### PR DESCRIPTION
#### Issue
- In `com.networknt.correlation.CorrelationHandlerTest`, the unit test `testGetWithoutTidNoAutogen()` can trigger `java.lang.AssertionError` when being run before the unit test `testGetWithoutTid()` in the same class because it pollutes state shared among tests.
- It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

Fixes #2012 

#### Solution
- Resetting the `CorrelationHandler.config` to default value after the test `testGetWithoutTidNoAutogen` is run using `CorrelationHandler.config.setAutogenCorrelationID(true);`