### PR TITLE
remove unused code in SimpleUndertowConnectionMaker

### DIFF
--- a/client/src/main/java/com/networknt/client/simplepool/undertow/SimpleUndertowConnectionMaker.java
+++ b/client/src/main/java/com/networknt/client/simplepool/undertow/SimpleUndertowConnectionMaker.java
@@ -100,20 +100,6 @@ public class SimpleUndertowConnectionMaker implements SimpleConnectionMaker
         return safeConnect(createConnectionTimeout, future);
     }
 
-    public SimpleConnection reuseConnection(long createConnectionTimeout, SimpleConnection connection) throws RuntimeException
-    {
-        if(connection == null)
-            return null;
-
-        if(!(connection.getRawConnection() instanceof ClientConnection))
-            throw new IllegalArgumentException("Attempt to reuse wrong connection type. Must be of type ClientConnection");
-
-        if(!connection.isOpen())
-            throw new RuntimeException("Reused-connection has been unexpectedly closed");
-
-        return connection;
-    }
-
     // PRIVATE METHODS
 
     private static OptionMap getConnectionOptions(boolean isHttp2) {


### PR DESCRIPTION
Issue: https://github.com/networknt/light-4j/issues/2023

The `reuseConnection()` method in `SimpleConnectionMaker` interface (`com.networknt.client.simplepool`) was removed in PR https://github.com/networknt/light-4j/pull/1963 (SimpleConnectionPool v2), so there is no longer a need for this method in SimpleUndertowConnectionMaker.