### PR TITLE
Ensure XnioSSL and XnioWorker resources are created only once in multithreaded environment (SimplePool v2) (1.6.x)

### DIFF
--- a/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
@@ -80,7 +80,9 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  *   Users must provide a fixed 'now' value for the current time.
  *   This freezes a single time value for all time-dependent properties.
- *   This is important when calculating an aggregate state based on the values of 2 or more time-dependent states.
+ *   This is important in methods that calculate a state based on the results of multiple reads from one or more
+ *   time-dependent variables over the course of executing the method. For consistency of the calculation, its important
+ *   that the values of time dependent variables do not change over the course of the execution of the method.
  *
  *   Not doing so (i.e.: not freezing the time) may allow inconsistent states to be reached.
  */

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
@@ -177,6 +177,7 @@ public final class SimpleConnectionState {
     /**
      * State Transition - Borrow
      *
+     * @param now the Unix Epoch time in milliseconds at which to evaluate whether there are borrowable connections or not
      * @return returns a ConnectionToken representing the borrowing of the connection
      * @throws RuntimeException      if the connection is closed
      * @throws IllegalStateException if the connection is not borrowable

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
@@ -182,7 +182,7 @@ public final class SimpleConnectionState {
      * @throws RuntimeException if the connection is closed
      * @throws IllegalStateException if the connection is not borrowable
      */
-    public synchronized ConnectionToken borrow(long connectionCreateTimeout, long now) throws RuntimeException {
+    public synchronized ConnectionToken borrow(long connectionCreateTimeout, long now) throws RuntimeException, IllegalStateException {
         /***
          * Connections can only be borrowed when the connection is in a BORROWABLE state.
          *

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleConnectionState.java
@@ -177,14 +177,11 @@ public final class SimpleConnectionState {
     /**
      * State Transition - Borrow
      *
-     * @param connectionCreateTimeout the amount of time in seconds to wait for a connection to be created before
-     *          throwing an exception
-     * @param now the Unix Epoch time in milliseconds at which to evaluate whether there are borrowable connections or not
      * @return returns a ConnectionToken representing the borrowing of the connection
-     * @throws RuntimeException if the connection is closed
+     * @throws RuntimeException      if the connection is closed
      * @throws IllegalStateException if the connection is not borrowable
      */
-    public synchronized ConnectionToken borrow(long connectionCreateTimeout, long now) throws RuntimeException, IllegalStateException {
+    public synchronized ConnectionToken borrow(long now) throws RuntimeException, IllegalStateException {
         /***
          * Connections can only be borrowed when the connection is in a BORROWABLE state.
          *
@@ -196,7 +193,7 @@ public final class SimpleConnectionState {
          *     long now = System.currentTimeMillis();
          *
          *     if(connectionState.borrowable(now))
-         *         connectionToken = connectionState.borrow(connectionCreateTimeout, now);
+         *         connectionToken = connectionState.borrow(now);
          *
          * Also note the use of a single consistent value for the current time ('now'). This ensures
          * that the state returned in the 'if' statement will still be true in the 'borrow' statement

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -41,7 +41,7 @@ import java.util.concurrent.ThreadLocalRandom;
  2. trackedConnections:      all connections tracked by the connection pool
  3. Borrowable:              all tracked connections that can be borrowed from
  4. Borrowed:                all tracked connections that have borrowed tokens
- 5. notBorrowedExpired:      all tracked connections that have both expired and not borrowed -- only these can be closed by the pool
+ 5. notBorrowedExpired:      all tracked connections that are both expired and not borrowed -- only these can be closed by the pool
  */
 public final class SimpleURIConnectionPool {
     private static final Logger logger = LoggerFactory.getLogger(SimpleURIConnectionPool.class);
@@ -95,7 +95,7 @@ public final class SimpleURIConnectionPool {
     public synchronized SimpleConnectionState.ConnectionToken borrow(long createConnectionTimeout, boolean isHttp2) throws RuntimeException {
         findAndCloseLeakedConnections();
         long now = System.currentTimeMillis();
-        
+
         final SimpleConnectionState connectionState;
 
         // update the connection pool's state

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -132,8 +132,11 @@ public final class SimpleURIConnectionPool {
     public synchronized void restore(SimpleConnectionState.ConnectionToken connectionToken) {
         long now = System.currentTimeMillis();
 
-        if(connectionToken != null)
-            connectionToken.state().restore(connectionToken);   // restore connection token
+        if(connectionToken != null) {
+            // restore connection token
+            SimpleConnectionState connectionState = connectionToken.state();
+            connectionState.restore(connectionToken);
+        }
 
         // update the connection pool's state
         applyAllConnectionStates(now);

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -195,12 +195,7 @@ public final class SimpleURIConnectionPool {
      */
     private void applyConnectionState(SimpleConnectionState connectionState, long now, RemoveFromTrackedConnections trackedConnectionRemover) {
 
-        /**
-         * Remove all references to closed connections
-         * After the connection is removed, the only reference to it will be in any unrestored ConnectionTokens,
-         * however, ConnectionTokens restored after the connection is closed will not be re-added to any sets
-         * (and will therefore be garbage collected)
-         */
+        // Remove all references to closed connections
         if(connectionState.closed()) {
             if(logger.isDebugEnabled())
                 logger.debug("[{}: CLOSED]: Connection unexpectedly closed - Stopping connection tracking", port(connectionState.connection()));
@@ -231,7 +226,13 @@ public final class SimpleURIConnectionPool {
     }
 
     /***
-     * Removes a connection (and its connection state) from being tracked by the pool
+     * Removes all references to a connection (and its connection state) from being tracked by the pool
+     *
+     * NOTE: Only call this method on closed connections
+     *
+     * After the connection is removed, the only reference to it will be in any unrestored ConnectionTokens.
+     * However, ConnectionTokens restored after the connection is closed will not be re-added to any sets
+     * (and will therefore be garbage collected)
      *
      * @param connectionState the connection state (and connection) to remove from connection tracking
      * @param trackedConnectionRemover a lamda expression to remove the state that depends on whether it is removed in

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -94,8 +94,8 @@ public final class SimpleURIConnectionPool {
      */
     public synchronized SimpleConnectionState.ConnectionToken borrow(long createConnectionTimeout, boolean isHttp2) throws RuntimeException {
         findAndCloseLeakedConnections();
-
         long now = System.currentTimeMillis();
+        
         final SimpleConnectionState connectionState;
 
         // update the connection pool's state
@@ -131,7 +131,6 @@ public final class SimpleURIConnectionPool {
      */
     public synchronized void restore(SimpleConnectionState.ConnectionToken connectionToken) {
         findAndCloseLeakedConnections();
-
         long now = System.currentTimeMillis();
 
         if(connectionToken != null) {

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -107,10 +107,8 @@ public final class SimpleURIConnectionPool {
             if (trackedConnections.size() < poolSize) {
                 connectionState = new SimpleConnectionState(EXPIRY_TIME, createConnectionTimeout, isHttp2, uri, allCreatedConnections, connectionMaker);
                 trackedConnections.add(connectionState);
-            } else {
-                findAndCloseLeakedConnections();
+            } else
                 throw new RuntimeException("An attempt was made to exceed the maximum size was of the " + uri.toString() + " connection pool");
-            }
         }
 
         SimpleConnectionState.ConnectionToken connectionToken = connectionState.borrow(createConnectionTimeout, now);

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -87,7 +87,7 @@ public final class SimpleURIConnectionPool {
      * @param isHttp2 if true, SimpleURIConnectionPool will attempt to establish an HTTP/2 connection, otherwise it will
      *          attempt to create an HTTP/1.1 connection
      * @return a ConnectionToken object that contains the borrowed connection. The thread using the connection must
-     *          return this connection to the pool when it is done with it by calling the borrow() method with the
+     *          return this connection to the pool when it is done with it by calling the restore() method with the
      *          ConnectionToken as the argument
      * @throws RuntimeException if connection creation takes longer than <code>createConnectionTimeout</code> seconds,
      *          or other issues that prevent connection creation

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -53,7 +53,7 @@ public final class SimpleURIConnectionPool {
     /** Connection Pool Sets
      *  These sets determine the mutable state of the connection pool
      */
-    /** The set of all connections created by the SimpleConnectionMaker for this uri */
+    /** The set of all connections created for the pool by the pool's SimpleConnectionMaker */
     private final Set<SimpleConnection> allCreatedConnections = ConcurrentHashMap.newKeySet();
     /** The set containing all connections known to this connection pool (It is not considered a state set) */
     private final Set<SimpleConnectionState> trackedConnections = new HashSet<>();

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -277,8 +277,8 @@ public final class SimpleURIConnectionPool {
      *     1) the connection-creation callback thread finishes creating the connection after a timeout has occurred
      *     2) the raw connection unexpectedly closes during the creation of its SimpleConnectionState
      *
-     * NOTE: Closing connection and modifying sets
-     *     readConnectionState() and findAndCloseLeakedConnections() are the only two methods that close connections
+     * NOTE: Closing connections and modifying sets
+     *     applyConnectionState() and findAndCloseLeakedConnections() are the only two methods that close connections
      *     and modify sets. This can be helpful to know for debugging since the sets comprise the entirety of the
      *     mutable state of this SimpleURIConnectionPool objects
      */

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -108,7 +108,7 @@ public final class SimpleURIConnectionPool {
                 connectionState = new SimpleConnectionState(EXPIRY_TIME, createConnectionTimeout, isHttp2, uri, allCreatedConnections, connectionMaker);
                 trackedConnections.add(connectionState);
             } else
-                throw new RuntimeException("An attempt was made to exceed the maximum size was of the " + uri.toString() + " connection pool");
+                throw new RuntimeException("An attempt was made to exceed the maximum size of the " + uri.toString() + " connection pool");
         }
 
         SimpleConnectionState.ConnectionToken connectionToken = connectionState.borrow(createConnectionTimeout, now);

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -165,7 +165,7 @@ public final class SimpleURIConnectionPool {
     private void applyAllConnectionStates(long now)
     {
         /**
-         * Sweep all known connections and apply their state changes to the connection pool's state. Also, close
+         * Sweep all known (tracked) connections and apply their state changes to the connection pool's state. Also, close
          * any unborrowed expired connections
          */
         final Iterator<SimpleConnectionState> trackedConnectionStates = trackedConnections.iterator();

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -132,17 +132,8 @@ public final class SimpleURIConnectionPool {
     public synchronized void restore(SimpleConnectionState.ConnectionToken connectionToken) {
         long now = System.currentTimeMillis();
 
-        if(connectionToken == null) {
-            // update the connection pool's state
-            applyAllConnectionStates(now);
-
-            findAndCloseLeakedConnections();
-            return;
-        }
-
-        // update this connection's state
-        SimpleConnectionState connectionState = connectionToken.state();
-        connectionState.restore(connectionToken);
+        if(connectionToken != null)
+            connectionToken.state().restore(connectionToken);   // restore connection token
 
         // update the connection pool's state
         applyAllConnectionStates(now);

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -111,7 +111,7 @@ public final class SimpleURIConnectionPool {
                 throw new RuntimeException("An attempt was made to exceed the maximum size of the " + uri.toString() + " connection pool");
         }
 
-        SimpleConnectionState.ConnectionToken connectionToken = connectionState.borrow(createConnectionTimeout, now);
+        SimpleConnectionState.ConnectionToken connectionToken = connectionState.borrow(now);
         applyConnectionState(connectionState, now, () -> trackedConnections.remove(connectionState));
 
         if(logger.isDebugEnabled()) logger.debug(showConnections("borrow"));

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -37,11 +37,11 @@ import java.util.concurrent.ThreadLocalRandom;
 
  Internally, SimpleURIConnectionPool organizes connections into 4 (possibly overlapping) sets:
 
- 1. allCreatedConnections    all connections created by connection makers are added to this set
- 2. trackedConnections:      the set of all connections tracked by the connection pool
- 3. Borrowable:              connection that can be borrowed from
- 4. Borrowed:                connections that have borrowed tokens
- 5. notBorrowedExpired:      connections that have no borrowed tokens -- only these can be closed by the pool
+ 1. allCreatedConnections    all connections created for the pool by the pool's SimpleConnectionMaker
+ 2. trackedConnections:      all connections tracked by the connection pool
+ 3. Borrowable:              all tracked connections that can be borrowed from
+ 4. Borrowed:                all tracked connections that have borrowed tokens
+ 5. notBorrowedExpired:      all tracked connections that have both expired and not borrowed -- only these can be closed by the pool
  */
 public final class SimpleURIConnectionPool {
     private static final Logger logger = LoggerFactory.getLogger(SimpleURIConnectionPool.class);

--- a/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
+++ b/client/src/main/java/com/networknt/client/simplepool/SimpleURIConnectionPool.java
@@ -177,10 +177,10 @@ public final class SimpleURIConnectionPool {
     /***
      * This method reads a connection and moves it to the correct sets based on its properties.
      * It will remove a connection from all sets (i.e.: stop tracking the connection) if it is closed.
-     * It will close unborrowed expired connections.
+     * It will also close unborrowed expired connections.
      *
      * NOTE: Closing connections and modifying sets
-     *     readConnectionState() and findAndCloseLeakedConnections() are the only two methods that close connections
+     *     applyConnectionState() and findAndCloseLeakedConnections() are the only two methods that close connections
      *     and modify sets. This can be helpful to know for debugging since the sets comprise the entirety of the
      *     mutable state of this SimpleURIConnectionPool objects
      *

--- a/client/src/main/java/com/networknt/client/simplepool/undertow/SimpleUndertowConnectionMaker.java
+++ b/client/src/main/java/com/networknt/client/simplepool/undertow/SimpleUndertowConnectionMaker.java
@@ -69,8 +69,8 @@ public class SimpleUndertowConnectionMaker implements SimpleConnectionMaker
         final Set<SimpleConnection> allCreatedConnections) throws RuntimeException
     {
         boolean isHttps = uri.getScheme().equalsIgnoreCase("https");
-        XnioSsl ssl = getSSL(isHttps, isHttp2);
         XnioWorker worker = getWorker(isHttp2);
+        XnioSsl ssl = getSSL(isHttps, isHttp2);
         OptionMap connectionOptions = getConnectionOptions(isHttp2);
         InetSocketAddress bindAddress = null;
 
@@ -132,17 +132,28 @@ public class SimpleUndertowConnectionMaker implements SimpleConnectionMaker
         return isHttp2 ? OptionMap.create(UndertowOptions.ENABLE_HTTP2, true) : OptionMap.EMPTY;
     }
 
+    /**
+     * WARNING: This is called by getSSL() which is synchronized. Therefore, this method must never call getSSL(),
+     *          or any method that transitively calls getSSL()
+     *
+     * @param isHttp2 if true, sets worker thread names to show HTTP2     *
+     * @return new XnioWorker
+     */
     private static XnioWorker getWorker(boolean isHttp2)
     {
         if(WORKER.get() != null) return WORKER.get();
 
-        Xnio xnio = Xnio.getInstance(Undertow.class.getClassLoader());
-        try {
-            // if WORKER is null, then set new WORKER otherwise leave existing WORKER
-            WORKER.compareAndSet(null, xnio.createWorker(null, getWorkerOptionMap(isHttp2)));
+        synchronized (SimpleUndertowConnectionMaker.class) {
+            // if WORKER is set then leave existing WORKER, otherwise set new WORKER
+            if(WORKER.get() != null) return WORKER.get();
 
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+            Xnio xnio = Xnio.getInstance(Undertow.class.getClassLoader());
+            try {
+                WORKER.set(xnio.createWorker(null, getWorkerOptionMap(isHttp2)));
+            } catch (IOException e) {
+                logger.error("Exception while creating new XnioWorker", e);
+                throw new RuntimeException(e);
+            }
         }
         return WORKER.get();
     }
@@ -157,22 +168,28 @@ public class SimpleUndertowConnectionMaker implements SimpleConnectionMaker
         return  optionBuild.getMap();
     }
 
+    /**
+     * WARNING: This calls getWorker() which is synchronized
+     *
+     * @param isHttps true if this is an HTTPS connection
+     * @param isHttp2 if true, sets worker thread names to show HTTP2
+     * @return new XnioSSL
+     */
     private static XnioSsl getSSL(boolean isHttps, boolean isHttp2)
     {
-        if(!isHttps)
-            return null;
-        if(SSL.get() != null)
-            return SSL.get();
+        if(!isHttps) return null;
+        if(SSL.get() != null) return SSL.get();
 
-        try {
-            // TODO: Should this be OptionMap.EMPTY ??
-            // if SSL is null, then set new SSL otherwise leave existing SSL
-            SSL.compareAndSet(
-                null,
-                new UndertowXnioSsl(getWorker(isHttp2).getXnio(), OptionMap.EMPTY, BUFFER_POOL, SimpleSSLContextMaker.createSSLContext()));
-        } catch (Exception e) {
-            logger.error("Exception while creating new shared UndertowXnioSsl used to create connections", e);
-            throw new RuntimeException(e);
+        synchronized (SimpleUndertowConnectionMaker.class) {
+            // if SSL is set then leave existing SSL, otherwise set new SSL
+            if(SSL.get() != null) return SSL.get();
+
+            try {
+                SSL.set(new UndertowXnioSsl(getWorker(isHttp2).getXnio(), OptionMap.EMPTY, BUFFER_POOL, SimpleSSLContextMaker.createSSLContext()));
+            } catch (Exception e) {
+                logger.error("Exception while creating new shared UndertowXnioSsl used to create connections", e);
+                throw new RuntimeException(e);
+            }
         }
         return SSL.get();
     }

--- a/client/src/main/java/com/networknt/client/simplepool/undertow/SimpleUndertowConnectionMaker.java
+++ b/client/src/main/java/com/networknt/client/simplepool/undertow/SimpleUndertowConnectionMaker.java
@@ -133,8 +133,10 @@ public class SimpleUndertowConnectionMaker implements SimpleConnectionMaker
     }
 
     /**
-     * WARNING: This is called by getSSL() which is synchronized. Therefore, this method must never call getSSL(),
-     *          or any method that transitively calls getSSL()
+     * Creates XnioWorker to make Undertow connections
+     *
+     * WARNING: This is called by getSSL(). Therefore, this method must never
+     *          call getSSL(), or any method that transitively calls getSSL()
      *
      * @param isHttp2 if true, sets worker thread names to show HTTP2     *
      * @return new XnioWorker
@@ -169,7 +171,9 @@ public class SimpleUndertowConnectionMaker implements SimpleConnectionMaker
     }
 
     /**
-     * WARNING: This calls getWorker() which is synchronized
+     * Creates SSLContext and XnioSsl
+     *
+     * WARNING: This calls getWorker()
      *
      * @param isHttps true if this is an HTTPS connection
      * @param isHttp2 if true, sets worker thread names to show HTTP2


### PR DESCRIPTION
NOTE: This solution should not be merged until after PR https://github.com/networknt/light-4j/pull/2042 is merged

Issue: https://github.com/networknt/light-4j/issues/2053

Ensure that XnioSsl, SSL Contexts, and XnioWorkers are only created once in SimpleUndertowConnectionMaker.