### PR TITLE
ExternalServiceHandler logging fix

### DIFF
--- a/egress-router/src/main/java/com/networknt/router/middleware/ServiceDictConfig.java
+++ b/egress-router/src/main/java/com/networknt/router/middleware/ServiceDictConfig.java
@@ -1,7 +1,7 @@
 package com.networknt.router.middleware;
 
 import com.networknt.config.Config;
-import com.networknt.config.ConfigException;
+import com.networknt.handler.HandlerUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/egress-router/src/main/java/com/networknt/router/middleware/ServiceDictHandler.java
+++ b/egress-router/src/main/java/com/networknt/router/middleware/ServiceDictHandler.java
@@ -1,6 +1,7 @@
 package com.networknt.router.middleware;
 
 import com.networknt.handler.Handler;
+import com.networknt.handler.HandlerUtils;
 import com.networknt.handler.MiddlewareHandler;
 import com.networknt.httpstring.AttachmentConstants;
 import com.networknt.httpstring.HttpStringConstants;

--- a/handler/src/main/java/com/networknt/handler/HandlerUtils.java
+++ b/handler/src/main/java/com/networknt/handler/HandlerUtils.java
@@ -1,9 +1,13 @@
-package com.networknt.router.middleware;
+package com.networknt.handler;
 
+import com.networknt.httpstring.AttachmentConstants;
+import com.networknt.utility.Constants;
 import com.networknt.utility.StringUtils;
+import io.undertow.server.HttpServerExchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class HandlerUtils {
@@ -66,6 +70,17 @@ public class HandlerUtils {
 
     public static String toInternalKey(String method, String path) {
         return String.format(INTERNAL_KEY_FORMAT, method, HandlerUtils.normalisePath(path));
+    }
+
+    public static void populateAuditAttachmentField(final HttpServerExchange exchange, String fieldName, String fieldValue) {
+        Map<String, Object> auditInfo = exchange.getAttachment(AttachmentConstants.AUDIT_INFO);
+        if(auditInfo == null) {
+            auditInfo = new HashMap<>();
+            auditInfo.put(fieldName, fieldValue);
+        } else if (!auditInfo.containsKey(Constants.ENDPOINT_STRING)) {
+            auditInfo.put(fieldName, fieldValue);
+        }
+        exchange.putAttachment(AttachmentConstants.AUDIT_INFO, auditInfo);
     }
 
 }

--- a/ingress-proxy/src/main/java/com/networknt/proxy/ExternalServiceHandler.java
+++ b/ingress-proxy/src/main/java/com/networknt/proxy/ExternalServiceHandler.java
@@ -5,11 +5,13 @@ import com.networknt.client.Http2Client;
 import com.networknt.client.ssl.TLSConfig;
 import com.networknt.handler.BuffersUtils;
 import com.networknt.handler.Handler;
+import com.networknt.handler.HandlerUtils;
 import com.networknt.handler.MiddlewareHandler;
 import com.networknt.handler.config.UrlRewriteRule;
 import com.networknt.httpstring.AttachmentConstants;
 import com.networknt.metrics.MetricsConfig;
 import com.networknt.metrics.AbstractMetricsHandler;
+import com.networknt.utility.Constants;
 import com.networknt.utility.ModuleRegistry;
 import io.undertow.Handlers;
 import io.undertow.connector.PooledByteBuffer;
@@ -133,6 +135,7 @@ public class ExternalServiceHandler implements MiddlewareHandler {
                         requestPath = exchange.getRequestPath();
                     }
 
+                    HandlerUtils.populateAuditAttachmentField(exchange, Constants.ENDPOINT_STRING, requestPath);
                     String method = exchange.getRequestMethod().toString();
                     String requestHost = parts[1];
                     String queryString = exchange.getQueryString();


### PR DESCRIPTION
- Moved HandlerUtils to Handler module
- Added new method to populate audit logging fields wherever needed
- ExternalServiceHandler now populates the endpoint field in the audit log correctly.