### PR TITLE
Add validation to matchPathToPattern method

### DIFF
--- a/utility/src/main/java/com/networknt/utility/StringUtils.java
+++ b/utility/src/main/java/com/networknt/utility/StringUtils.java
@@ -1498,6 +1498,9 @@ public class StringUtils {
     public static boolean matchPathToPattern(String requestPath, String endpointPattern) {
         String[] pathPatternParts = endpointPattern.split("/");
         String[] pathParts = requestPath.split("/");
+        if (pathPatternParts.length != pathParts.length) {
+            return false;
+        }
 
         boolean isMatch = true;
         for (int i = 0; i < pathPatternParts.length; i++) {

--- a/utility/src/test/java/com/networknt/utility/StringUtilsTest.java
+++ b/utility/src/test/java/com/networknt/utility/StringUtilsTest.java
@@ -81,5 +81,7 @@ public class StringUtilsTest {
         pattern = "/gateway/dev/ph-l4j-files/file?version=1";
         Assert.assertTrue(StringUtils.matchPathToPattern("/gateway/dev/ph-l4j-files/file?version=1", pattern));
 
+        pattern = "/gateway/dev/ph-l4j-files/file/05048267?version=1";
+        Assert.assertFalse(StringUtils.matchPathToPattern("/gateway/dev/ph-l4j-files/file?version=1", pattern));
     }
 }


### PR DESCRIPTION
Added a length validation to check if the base path and the request path are of equal length.

This is to avoid index out of bound issues that can be encountered for method rewrite rules.