### PR TITLE
light-4j 1.6.x : Add options to allow JWTVerifyHandler to skip token expiration date and token signature

### DIFF
--- a/security/src/main/java/com/networknt/security/JwtVerifier.java
+++ b/security/src/main/java/com/networknt/security/JwtVerifier.java
@@ -211,7 +211,7 @@ public class JwtVerifier {
      * @throws ExpiredTokenException throw when the token is expired
      */
     public JwtClaims verifyJwt(String jwt, boolean ignoreExpiry, boolean isToken) throws InvalidJwtException, ExpiredTokenException {
-        return verifyJwt(jwt, ignoreExpiry, isToken, this::getKeyResolver);
+        return verifyJwt(jwt, isToken, this::getKeyResolver);
     }
 
     /**
@@ -223,14 +223,14 @@ public class JwtVerifier {
      * token in the request header to renew the expired token.
      *
      * @param jwt String of Json web token
-     * @param ignoreExpiry If true, don't verify if the token is expired.
+     * //@param ignoreExpiry If true, don't verify if the token is expired.
      * @param isToken True if the jwt is an OAuth 2.0 access token
      * @param getKeyResolver How to get VerificationKeyResolver
      * @return JwtClaims object
      * @throws InvalidJwtException InvalidJwtException
      * @throws ExpiredTokenException ExpiredTokenException
      */
-    public JwtClaims verifyJwt(String jwt, boolean ignoreExpiry, boolean isToken, BiFunction<String, Boolean, VerificationKeyResolver> getKeyResolver)
+    public JwtClaims verifyJwt(String jwt, boolean isToken, BiFunction<String, Boolean, VerificationKeyResolver> getKeyResolver)
             throws InvalidJwtException, ExpiredTokenException {
         JwtClaims claims;
 
@@ -271,7 +271,7 @@ public class JwtVerifier {
         String kid = structure.getKeyIdHeaderValue();
 
         // so we do expiration check here manually as we have the claim already for kid
-        // if ignoreExpiry is true, verify expiration of the token
+        // if ignoreExpiry is false, verify expiration of the tokens
         if(!ignoreExpiry) {
             try {
                 if ((NumericDate.now().getValue() - secondsOfAllowedClockSkew) >= claims.getExpirationTime().getValue())

--- a/security/src/main/java/com/networknt/security/JwtVerifier.java
+++ b/security/src/main/java/com/networknt/security/JwtVerifier.java
@@ -237,7 +237,6 @@ public class JwtVerifier {
      * token in the request header to renew the expired token.
      *
      * @param jwt String of Json web token
-     * //@param ignoreExpiry If true, don't verify if the token is expired.
      * @param isToken True if the jwt is an OAuth 2.0 access token
      * @param getKeyResolver How to get VerificationKeyResolver
      * @return JwtClaims object

--- a/security/src/main/java/com/networknt/security/JwtVerifier.java
+++ b/security/src/main/java/com/networknt/security/JwtVerifier.java
@@ -235,7 +235,7 @@ public class JwtVerifier {
         JwtClaims claims;
 
         if(Boolean.TRUE.equals(enableJwtCache)) {
-            claims = cache.getIfPresent(jwt);
+             claims = cache.getIfPresent(jwt);
             if(claims != null) {
                 if(!ignoreExpiry) {
                     try {

--- a/security/src/main/java/com/networknt/security/JwtVerifier.java
+++ b/security/src/main/java/com/networknt/security/JwtVerifier.java
@@ -234,8 +234,6 @@ public class JwtVerifier {
             throws InvalidJwtException, ExpiredTokenException {
         JwtClaims claims;
 
-        ignoreExpiry = this.ignoreExpiry; //getting the value from the security.yml
-
         if(Boolean.TRUE.equals(enableJwtCache)) {
             claims = cache.getIfPresent(jwt);
             if(claims != null) {

--- a/security/src/main/java/com/networknt/security/JwtVerifier.java
+++ b/security/src/main/java/com/networknt/security/JwtVerifier.java
@@ -283,7 +283,7 @@ public class JwtVerifier {
         String kid = structure.getKeyIdHeaderValue();
 
         // so we do expiration check here manually as we have the claim already for kid
-        // if ignoreExpiry is false, verify expiration of the tokens
+        // if ignoreExpiry is false, verify expiration of the token
         if(!ignoreExpiry) {
             try {
                 if ((NumericDate.now().getValue() - secondsOfAllowedClockSkew) >= claims.getExpirationTime().getValue())

--- a/security/src/main/resources/config/security.yml
+++ b/security/src/main/resources/config/security.yml
@@ -40,8 +40,8 @@ enableJwtCache: true
 # or official environment that use other OAuth 2.0 providers.
 bootstrapFromKeyService: false
 
-# To skip JWT token Signature Validation if it is true
+# Set to true to skip JWT signature validation during token verification. Only valid when enableVerifyJwt is true.
 skipSignatureCheck: false
 
-# If ignoreExpiry is false, verify expiration date of the token
+# Set to true to ignore JWT expiry date during token verification. Only valid when enableVerifyJwt is true.
 ignoreExpiry: false

--- a/security/src/main/resources/config/security.yml
+++ b/security/src/main/resources/config/security.yml
@@ -40,5 +40,5 @@ enableJwtCache: true
 # or official environment that use other OAuth 2.0 providers.
 bootstrapFromKeyService: false
 
-#To skip JWT token Signature and Expiration Validation if true
+#To skip JWT token Signature and Expiration Validation if it is true
 skipSignatureAndExpirationCheck: false

--- a/security/src/main/resources/config/security.yml
+++ b/security/src/main/resources/config/security.yml
@@ -41,7 +41,7 @@ enableJwtCache: true
 bootstrapFromKeyService: false
 
 #To skip JWT token Signature Validation if it is true
-skipSignatureCheck: false
+#skipSignatureCheck: false
 
 #If ignoreExpiry is false, verify expiration of the token
-ignoreExpiry: false
+#ignoreExpiry: false

--- a/security/src/main/resources/config/security.yml
+++ b/security/src/main/resources/config/security.yml
@@ -40,8 +40,8 @@ enableJwtCache: true
 # or official environment that use other OAuth 2.0 providers.
 bootstrapFromKeyService: false
 
-#To skip JWT token Signature Validation if it is true
+# To skip JWT token Signature Validation if it is true
 skipSignatureCheck: false
 
-#If ignoreExpiry is false, verify expiration date of the token
+# If ignoreExpiry is false, verify expiration date of the token
 ignoreExpiry: false

--- a/security/src/main/resources/config/security.yml
+++ b/security/src/main/resources/config/security.yml
@@ -43,5 +43,5 @@ bootstrapFromKeyService: false
 #To skip JWT token Signature Validation if it is true
 skipSignatureCheck: false
 
-#If ignoreExpiry is false, verify expiration of the token
+#If ignoreExpiry is false, verify expiration date of the token
 ignoreExpiry: false

--- a/security/src/main/resources/config/security.yml
+++ b/security/src/main/resources/config/security.yml
@@ -39,3 +39,6 @@ enableJwtCache: true
 # the first token is arrived. Default to false for dev environment without oauth2 server
 # or official environment that use other OAuth 2.0 providers.
 bootstrapFromKeyService: false
+
+#To skip JWT token Signature and Expiration Validation if true
+skipSignatureAndExpirationCheck: false

--- a/security/src/main/resources/config/security.yml
+++ b/security/src/main/resources/config/security.yml
@@ -41,7 +41,7 @@ enableJwtCache: true
 bootstrapFromKeyService: false
 
 #To skip JWT token Signature Validation if it is true
-#skipSignatureCheck: false
+skipSignatureCheck: false
 
 #If ignoreExpiry is false, verify expiration of the token
-#ignoreExpiry: false
+ignoreExpiry: false

--- a/security/src/main/resources/config/security.yml
+++ b/security/src/main/resources/config/security.yml
@@ -40,5 +40,8 @@ enableJwtCache: true
 # or official environment that use other OAuth 2.0 providers.
 bootstrapFromKeyService: false
 
-#To skip JWT token Signature and Expiration Validation if it is true
-skipSignatureAndExpirationCheck: false
+#To skip JWT token Signature Validation if it is true
+skipSignatureCheck: false
+
+#If ignoreExpiry is false, verify expiration of the token
+ignoreExpiry: false

--- a/security/src/test/java/com/networknt/security/JwtVerifierTest.java
+++ b/security/src/test/java/com/networknt/security/JwtVerifierTest.java
@@ -107,13 +107,13 @@ public class JwtVerifierTest {
     }
 
     @Test
-    public void testVerifyJwt_skipSignatureAndExpirationCheck_True() throws Exception {
+    public void testVerifyJwt_skipSignature_True() throws Exception {
         JwtClaims claims = ClaimsUtil.getTestClaims("steve", "EMPLOYEE", "f7d42348-c647-4efb-a52d-4c5787421e72", Arrays.asList("write:pets", "read:pets"), "user");
         String jwt = JwtIssuer.getJwt(claims);
         claims = null;
         Assert.assertNotNull(jwt);
         JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
-        jwtVerifier.skipSignatureAndExpirationCheck = true;
+        jwtVerifier.skipSignatureCheck = true;
         try {
             claims = jwtVerifier.verifyJwt(jwt, false, true);
         } catch (Exception e) {
@@ -176,6 +176,7 @@ public class JwtVerifierTest {
         System.out.print("JWT = " + jwt);
 
         JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
+        jwtVerifier.ignoreExpiry = true;
         JwtClaims claims = jwtVerifier.verifyJwt(jwt, true, true, (kId, isToken) -> {
             try {
                 // use public key to create the the JsonWebKey
@@ -193,7 +194,7 @@ public class JwtVerifierTest {
     }
 
     @Test
-    public void testVerifyJwtByJsonWebKeys_skipSignatureAndExpirationCheck_True() throws Exception {
+    public void testVerifyJwtByJsonWebKeys_skipSignature_True() throws Exception {
         Map<String, Object> secretConfig = Config.getInstance().getJsonMapConfig(JwtIssuer.SECRET_CONFIG);
         JwtConfig jwtConfig = (JwtConfig) Config.getInstance().getJsonObjectConfig(JwtIssuer.JWT_CONFIG, JwtConfig.class);
 
@@ -235,7 +236,8 @@ public class JwtVerifierTest {
         System.out.print("JWT = " + jwt);
 
         JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
-        jwtVerifier.skipSignatureAndExpirationCheck = true;
+        jwtVerifier.ignoreExpiry = true;
+        jwtVerifier.skipSignatureCheck = true;
         JwtClaims claims = jwtVerifier.verifyJwt(jwt, true, true, (kId, isToken) -> {
             try {
                 // use public key to create the the JsonWebKey
@@ -284,13 +286,13 @@ public class JwtVerifierTest {
     }
 
     @Test
-    public void testVerifyToken_skipSignatureAndExpirationCheck_True() throws Exception {
+    public void testVerifyToken_skipSignature_True() throws Exception {
         JwtClaims claims = ClaimsUtil.getTestClaims("steve", "EMPLOYEE", "f7d42348-c647-4efb-a52d-4c5787421e72", Arrays.asList("write:pets", "read:pets"), "user");
         String jwt = JwtIssuer.getJwt(claims);
         claims = null;
         Assert.assertNotNull(jwt);
         JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
-        jwtVerifier.skipSignatureAndExpirationCheck = true;
+        jwtVerifier.skipSignatureCheck = true;
         try {
             claims = jwtVerifier.verifyJwt(jwt, false, true);
         } catch (Exception e) {
@@ -341,7 +343,7 @@ public class JwtVerifierTest {
         claims = null;
         Assert.assertNotNull(jwt);
         JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
-        jwtVerifier.skipSignatureAndExpirationCheck = true;
+        jwtVerifier.skipSignatureCheck = true;
         try {
             claims = jwtVerifier.verifyJwt(jwt, false, false);
         } catch (Exception e) {

--- a/security/src/test/java/com/networknt/security/JwtVerifierTest.java
+++ b/security/src/test/java/com/networknt/security/JwtVerifierTest.java
@@ -96,7 +96,6 @@ public class JwtVerifierTest {
         }
         Assert.assertNotNull(claims);
         Assert.assertEquals("steve", claims.getStringClaimValue(Constants.USER_ID_STRING));
-
         try {
             claims = jwtVerifier.verifyJwt(jwt, false, true);
             Assert.assertNotNull(claims);

--- a/security/src/test/java/com/networknt/security/JwtVerifierTest.java
+++ b/security/src/test/java/com/networknt/security/JwtVerifierTest.java
@@ -107,6 +107,33 @@ public class JwtVerifierTest {
     }
 
     @Test
+    public void testVerifyJwt_skipSignatureAndExpirationCheck_True() throws Exception {
+        JwtClaims claims = ClaimsUtil.getTestClaims("steve", "EMPLOYEE", "f7d42348-c647-4efb-a52d-4c5787421e72", Arrays.asList("write:pets", "read:pets"), "user");
+        String jwt = JwtIssuer.getJwt(claims);
+        claims = null;
+        Assert.assertNotNull(jwt);
+        JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
+        jwtVerifier.skipSignatureAndExpirationCheck = true;
+        try {
+            claims = jwtVerifier.verifyJwt(jwt, false, true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        Assert.assertNotNull(claims);
+        Assert.assertEquals("steve", claims.getStringClaimValue(Constants.USER_ID_STRING));
+
+        try {
+            claims = jwtVerifier.verifyJwt(jwt, false, true);
+            Assert.assertNotNull(claims);
+            Assert.assertEquals("steve", claims.getStringClaimValue(Constants.USER_ID_STRING));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        System.out.println("jwtClaims = " + claims);
+    }
+
+    @Test
     public void testVerifyJwtByJsonWebKeys() throws Exception {
         Map<String, Object> secretConfig = Config.getInstance().getJsonMapConfig(JwtIssuer.SECRET_CONFIG);
         JwtConfig jwtConfig = (JwtConfig) Config.getInstance().getJsonObjectConfig(JwtIssuer.JWT_CONFIG, JwtConfig.class);
@@ -165,6 +192,66 @@ public class JwtVerifierTest {
         Assert.assertEquals(iss, claims.getStringClaimValue("iss"));
     }
 
+    @Test
+    public void testVerifyJwtByJsonWebKeys_skipSignatureAndExpirationCheck_True() throws Exception {
+        Map<String, Object> secretConfig = Config.getInstance().getJsonMapConfig(JwtIssuer.SECRET_CONFIG);
+        JwtConfig jwtConfig = (JwtConfig) Config.getInstance().getJsonObjectConfig(JwtIssuer.JWT_CONFIG, JwtConfig.class);
+
+        String fileName = jwtConfig.getKey().getFilename();
+        String alias = jwtConfig.getKey().getKeyName();
+
+        KeyStore ks = loadKeystore(fileName, (String)secretConfig.get(JwtIssuer.JWT_PRIVATE_KEY_PASSWORD));
+        Key privateKey = ks.getKey(alias, ((String) secretConfig.get(JwtIssuer.JWT_PRIVATE_KEY_PASSWORD)).toCharArray());
+
+        JsonWebSignature jws = new JsonWebSignature();
+
+        String iss = "my.test.iss";
+        JwtClaims jwtClaims = JwtClaims.parse("{\n" +
+                "  \"sub\": \"5745ed4b-0158-45ff-89af-4ce99bc6f4de\",\n" +
+                "  \"iss\": \"" + iss  +"\",\n" +
+                "  \"subject_type\": \"client-id\",\n" +
+                "  \"exp\": 1557419531,\n" +
+                "  \"iat\": 1557419231,\n" +
+                "  \"scope\": [\n" +
+                "    \"my.test.scope.read\",\n" +
+                "    \"my.test.scope.write\",\n" +
+                "  ],\n" +
+                "  \"consumer_application_id\": \"389\",\n" +
+                "  \"request_transit\": \"63092\"\n" +
+                "}");
+
+        // The payload of the JWS is JSON content of the JWT Claims
+        jws.setPayload(jwtClaims.toJson());
+
+        // use private key to sign the JWT
+        jws.setKey(privateKey);
+
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
+
+        String jwt = jws.getCompactSerialization();
+
+        Assert.assertNotNull(jwt);
+
+        System.out.print("JWT = " + jwt);
+
+        JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
+        jwtVerifier.skipSignatureAndExpirationCheck = true;
+        JwtClaims claims = jwtVerifier.verifyJwt(jwt, true, true, (kId, isToken) -> {
+            try {
+                // use public key to create the the JsonWebKey
+                Key publicKey = ks.getCertificate(alias).getPublicKey();
+                PublicJsonWebKey jwk = PublicJsonWebKey.Factory.newPublicJwk(publicKey);
+                List<JsonWebKey> jwkList = Arrays.asList(jwk);
+                return new JwksVerificationKeyResolver(jwkList);
+            } catch (JoseException | KeyStoreException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        Assert.assertNotNull(claims);
+        Assert.assertEquals(iss, claims.getStringClaimValue("iss"));
+    }
+
     private static KeyStore loadKeystore(String fileName, String keyStorePass) throws Exception {
         KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
         char[] passwd = keyStorePass.toCharArray();
@@ -197,12 +284,64 @@ public class JwtVerifierTest {
     }
 
     @Test
+    public void testVerifyToken_skipSignatureAndExpirationCheck_True() throws Exception {
+        JwtClaims claims = ClaimsUtil.getTestClaims("steve", "EMPLOYEE", "f7d42348-c647-4efb-a52d-4c5787421e72", Arrays.asList("write:pets", "read:pets"), "user");
+        String jwt = JwtIssuer.getJwt(claims);
+        claims = null;
+        Assert.assertNotNull(jwt);
+        JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
+        jwtVerifier.skipSignatureAndExpirationCheck = true;
+        try {
+            claims = jwtVerifier.verifyJwt(jwt, false, true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        Assert.assertNotNull(claims);
+        Assert.assertEquals("steve", claims.getStringClaimValue(Constants.USER_ID_STRING));
+
+        try {
+            claims = jwtVerifier.verifyJwt(jwt, false, true);
+            Assert.assertNotNull(claims);
+            Assert.assertEquals("steve", claims.getStringClaimValue(Constants.USER_ID_STRING));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        System.out.println("jwtClaims = " + claims);
+    }
+
+    @Test
     public void testVerifySign() throws Exception {
         JwtClaims claims = ClaimsUtil.getTestClaims("steve", "EMPLOYEE", "f7d42348-c647-4efb-a52d-4c5787421e72", Arrays.asList("write:pets", "read:pets"), "user");
         String jwt = JwtIssuer.getJwt(claims);
         claims = null;
         Assert.assertNotNull(jwt);
         JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
+        try {
+            claims = jwtVerifier.verifyJwt(jwt, false, false);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        Assert.assertNotNull(claims);
+        Assert.assertEquals("steve", claims.getStringClaimValue(Constants.USER_ID_STRING));
+
+        try {
+            claims = jwtVerifier.verifyJwt(jwt, false, false);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        System.out.println("jwtClaims = " + claims);
+    }
+
+    @Test
+    public void testVerifySign_skipSignatureAndExpirationCheck_True() throws Exception {
+        JwtClaims claims = ClaimsUtil.getTestClaims("steve", "EMPLOYEE", "f7d42348-c647-4efb-a52d-4c5787421e72", Arrays.asList("write:pets", "read:pets"), "user");
+        String jwt = JwtIssuer.getJwt(claims);
+        claims = null;
+        Assert.assertNotNull(jwt);
+        JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
+        jwtVerifier.skipSignatureAndExpirationCheck = true;
         try {
             claims = jwtVerifier.verifyJwt(jwt, false, false);
         } catch (Exception e) {

--- a/security/src/test/java/com/networknt/security/JwtVerifierTest.java
+++ b/security/src/test/java/com/networknt/security/JwtVerifierTest.java
@@ -177,7 +177,7 @@ public class JwtVerifierTest {
 
         JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
         jwtVerifier.ignoreExpiry = true;
-        JwtClaims claims = jwtVerifier.verifyJwt(jwt, true, true, (kId, isToken) -> {
+        JwtClaims claims = jwtVerifier.verifyJwt(jwt, true, (kId, isToken) -> {
             try {
                 // use public key to create the the JsonWebKey
                 Key publicKey = ks.getCertificate(alias).getPublicKey();
@@ -238,7 +238,7 @@ public class JwtVerifierTest {
         JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
         jwtVerifier.ignoreExpiry = true;
         jwtVerifier.skipSignatureCheck = true;
-        JwtClaims claims = jwtVerifier.verifyJwt(jwt, true, true, (kId, isToken) -> {
+        JwtClaims claims = jwtVerifier.verifyJwt(jwt, true, (kId, isToken) -> {
             try {
                 // use public key to create the the JsonWebKey
                 Key publicKey = ks.getCertificate(alias).getPublicKey();

--- a/security/src/test/java/com/networknt/security/JwtVerifierTest.java
+++ b/security/src/test/java/com/networknt/security/JwtVerifierTest.java
@@ -99,6 +99,8 @@ public class JwtVerifierTest {
 
         try {
             claims = jwtVerifier.verifyJwt(jwt, false, true);
+            Assert.assertNotNull(claims);
+            Assert.assertEquals("steve", claims.getStringClaimValue(Constants.USER_ID_STRING));
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -107,13 +109,14 @@ public class JwtVerifierTest {
     }
 
     @Test
-    public void testVerifyJwt_skipSignature_True() throws Exception {
+    public void testVerifyJwt_ignoreExpiry_skipSignature_True() throws Exception {
         JwtClaims claims = ClaimsUtil.getTestClaims("steve", "EMPLOYEE", "f7d42348-c647-4efb-a52d-4c5787421e72", Arrays.asList("write:pets", "read:pets"), "user");
         String jwt = JwtIssuer.getJwt(claims);
         claims = null;
         Assert.assertNotNull(jwt);
         JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
         jwtVerifier.skipSignatureCheck = true;
+        jwtVerifier.ignoreExpiry = true;
         try {
             claims = jwtVerifier.verifyJwt(jwt, false, true);
         } catch (Exception e) {
@@ -194,7 +197,7 @@ public class JwtVerifierTest {
     }
 
     @Test
-    public void testVerifyJwtByJsonWebKeys_skipSignature_True() throws Exception {
+    public void testVerifyJwtByJsonWebKeys_ignoreExpiry_skipSignature_True() throws Exception {
         Map<String, Object> secretConfig = Config.getInstance().getJsonMapConfig(JwtIssuer.SECRET_CONFIG);
         JwtConfig jwtConfig = (JwtConfig) Config.getInstance().getJsonObjectConfig(JwtIssuer.JWT_CONFIG, JwtConfig.class);
 
@@ -278,6 +281,8 @@ public class JwtVerifierTest {
 
         try {
             claims = jwtVerifier.verifyJwt(jwt, false, true);
+            Assert.assertNotNull(claims);
+            Assert.assertEquals("steve", claims.getStringClaimValue(Constants.USER_ID_STRING));
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -286,13 +291,14 @@ public class JwtVerifierTest {
     }
 
     @Test
-    public void testVerifyToken_skipSignature_True() throws Exception {
+    public void testVerifyToken_ignoreExpiry_skipSignature_True() throws Exception {
         JwtClaims claims = ClaimsUtil.getTestClaims("steve", "EMPLOYEE", "f7d42348-c647-4efb-a52d-4c5787421e72", Arrays.asList("write:pets", "read:pets"), "user");
         String jwt = JwtIssuer.getJwt(claims);
         claims = null;
         Assert.assertNotNull(jwt);
         JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
         jwtVerifier.skipSignatureCheck = true;
+        jwtVerifier.ignoreExpiry = true;
         try {
             claims = jwtVerifier.verifyJwt(jwt, false, true);
         } catch (Exception e) {
@@ -329,6 +335,8 @@ public class JwtVerifierTest {
 
         try {
             claims = jwtVerifier.verifyJwt(jwt, false, false);
+            Assert.assertNotNull(claims);
+            Assert.assertEquals("steve", claims.getStringClaimValue(Constants.USER_ID_STRING));
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -337,13 +345,14 @@ public class JwtVerifierTest {
     }
 
     @Test
-    public void testVerifySign_skipSignatureAndExpirationCheck_True() throws Exception {
+    public void testVerifySign_ignoreExpiry_skipSignature_True() throws Exception {
         JwtClaims claims = ClaimsUtil.getTestClaims("steve", "EMPLOYEE", "f7d42348-c647-4efb-a52d-4c5787421e72", Arrays.asList("write:pets", "read:pets"), "user");
         String jwt = JwtIssuer.getJwt(claims);
         claims = null;
         Assert.assertNotNull(jwt);
         JwtVerifier jwtVerifier = new JwtVerifier(Config.getInstance().getJsonMapConfig(CONFIG_NAME));
         jwtVerifier.skipSignatureCheck = true;
+        jwtVerifier.ignoreExpiry = true;
         try {
             claims = jwtVerifier.verifyJwt(jwt, false, false);
         } catch (Exception e) {
@@ -354,6 +363,8 @@ public class JwtVerifierTest {
 
         try {
             claims = jwtVerifier.verifyJwt(jwt, false, false);
+            Assert.assertNotNull(claims);
+            Assert.assertEquals("steve", claims.getStringClaimValue(Constants.USER_ID_STRING));
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION


In security module/service.yml of light-4j, two more configuration parameters were added for a more flexible token validation(token expiration date and token signature):

#To skip JWT token Signature Validation if it is true
skipSignatureCheck: false

#If ignoreExpiry is false, verify expiration of the token
ignoreExpiry: false