### PR TITLE
Change default value of enabled to false and fix a bug

### DIFF
--- a/config/src/main/java/com/networknt/config/ConfigInjection.java
+++ b/config/src/main/java/com/networknt/config/ConfigInjection.java
@@ -92,7 +92,7 @@ public class ConfigInjection {
     // Return the list of exclusion files list which includes the names of config files that shouldn't be injected
     // Double check values and exclusions to ensure no dead loop
     public static boolean isExclusionConfigFile(String configName) {
-        List<Object> exclusionConfigFileList = (exclusionMap == null) ? new ArrayList<>() : (List<Object>) exclusionMap.get(EXCLUSION_CONFIG_FILE_LIST);
+        List<Object> exclusionConfigFileList = (exclusionMap == null || exclusionMap.get(EXCLUSION_CONFIG_FILE_LIST) == null) ? new ArrayList<>() : (List<Object>) exclusionMap.get(EXCLUSION_CONFIG_FILE_LIST);
         return SCALABLE_CONFIG.equals(configName)
                 || exclusionConfigFileList.contains(configName);
     }

--- a/handler-config/src/main/resources/config/handler.yaml
+++ b/handler-config/src/main/resources/config/handler.yaml
@@ -1,4 +1,4 @@
-enabled: true
+enabled: false
 # Configuration for the LightHttpHandler. The handler is the base class  for all middleware, server and health handlers
 # set the Status Object in the AUDIT_INFO, for auditing purposes
 # default, if not set:false


### PR DESCRIPTION
## handler.yaml
Due to the code in the following screenshot, I believe the default value in the handler.yaml file of the handler-config module should be set to false; otherwise, it will affect the loading of the HandlerProvider interface implementation class in service.yml.

Server.java:
![image](https://github.com/user-attachments/assets/5afee7ac-b16a-47ff-8ea7-a903579ff6bf)

## NullPointerException

Avoid null pointer exceptions when the exclusionConfigFileList property is not configured in config.yml.
