### PR TITLE
TokenHandler + ClientConfig Fix

### DIFF
--- a/client-config/src/main/java/com/networknt/client/AuthServerConfig.java
+++ b/client-config/src/main/java/com/networknt/client/AuthServerConfig.java
@@ -1,5 +1,7 @@
 package com.networknt.client;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.config.schema.ArrayField;
 import com.networknt.config.schema.BooleanField;
 import com.networknt.config.schema.IntegerField;
@@ -7,62 +9,66 @@ import com.networknt.config.schema.StringField;
 
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AuthServerConfig {
 
     @StringField(
             configFieldName = "server_url"
     )
-    private String server_url;
+    @JsonProperty("server_url")
+    private String serverUrl = null;
 
     @StringField(
             configFieldName = "proxyHost"
     )
-    private String proxyHost;
+    private String proxyHost = null;
 
     @IntegerField(
             configFieldName = "proxyPort",
             min = 0,
             max = 65535
     )
-    private int proxyPort;
+    private Integer proxyPort = null;
 
     @BooleanField(
             configFieldName = "enableHttp2"
     )
-    private boolean enableHttp2;
+    private Boolean enableHttp2 = null;
 
     @StringField(
             configFieldName = "uri"
     )
-    private String uri;
+    private String uri = null;
 
     @StringField(
             configFieldName = "client_id"
     )
-    private char[] client_id;
+    @JsonProperty("client_id")
+    private char[] clientId = null;
 
     @StringField(
             configFieldName = "client_secret"
     )
-    private char[] client_secret;
+    @JsonProperty("client_secret")
+    private char[] clientSecret = null;
 
     @ArrayField(
             configFieldName = "scope",
             items = String.class
     )
-    private List<String> scope;
+    private List<String> scope = null;
 
     @StringField(
             configFieldName = "audience"
     )
-    private String audience;
+    private String audience = null;
 
 
-    public String getServer_url() {
-        return server_url;
+    public String getServerUrl() {
+        return serverUrl;
     }
 
-    public boolean isEnableHttp2() {
+    public Boolean isEnableHttp2() {
         return enableHttp2;
     }
 
@@ -70,12 +76,12 @@ public class AuthServerConfig {
         return uri;
     }
 
-    public char[] getClient_id() {
-        return client_id;
+    public char[] getClientId() {
+        return clientId;
     }
 
-    public char[] getClient_secret() {
-        return client_secret;
+    public char[] getClientSecret() {
+        return clientSecret;
     }
 
     public List<String> getScope() {
@@ -90,7 +96,7 @@ public class AuthServerConfig {
         return proxyHost;
     }
 
-    public int getProxyPort() {
+    public Integer getProxyPort() {
         return proxyPort;
     }
 }

--- a/client-config/src/main/java/com/networknt/client/ClientConfig.java
+++ b/client-config/src/main/java/com/networknt/client/ClientConfig.java
@@ -1,5 +1,7 @@
 package com.networknt.client;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.networknt.config.Config;
 import com.networknt.config.JsonMapper;
@@ -17,14 +19,28 @@ import java.util.Map;
         configDescription = "This is the configuration file for light-4j Http2Client and jdk 11 http-client.",
         outputFormats = {OutputFormat.JSON_SCHEMA, OutputFormat.YAML}
 )
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public final class ClientConfig {
     private static final Logger logger = LoggerFactory.getLogger(ClientConfig.class);
-    public static final String CONFIG_NAME = "client";
-    public static final String REQUEST = "request";
+    public static final String TOKEN = "token";
+    public static final String MULTIPLE_AUTH_SERVERS = "multipleAuthServers";
+    public static final String DEREF = "deref";
+    public static final String SIGN = "sign";
+    public static final String CACHE = "cache";
+    public static final String TOKEN_RENEW_BEFORE_EXPIRED = "tokenRenewBeforeExpired";
+    public static final String EXPIRED_REFRESH_RETRY_DELAY = "expiredRefreshRetryDelay";
+    public static final String EARLY_REFRESH_RETRY_DELAY = "earlyRefreshRetryDelay";
     public static final String SERVER_URL = "server_url";
+    public static final String SERVICE_ID = "serviceId";
     public static final String PROXY_HOST = "proxyHost";
     public static final String PROXY_PORT = "proxyPort";
-    public static final String SERVICE_ID = "serviceId";
+    public static final String ENABLE_HTTP_2 = "enableHttp2";
+    public static final String AUTHORIZATION_CODE = "authorization_code";
+    public static final String CLIENT_CREDENTIALS = "client_credentials";
+    public static final String REFRESH_TOKEN = "refresh_token";
+    public static final String KEY = "key";
+    public static final String CONFIG_NAME = "client";
+    public static final String REQUEST = "request";
     public static final String URI = "uri";
     public static final String TLS = "tls";
     public static final String CLIENT_ID = "client_id";
@@ -32,68 +48,85 @@ public final class ClientConfig {
     public static final String AUDIENCE = "audience";
     public static final String CSRF = "csrf";
     public static final String REDIRECT_URI = "redirect_uri";
-    public static final String REFRESH_TOKEN = "refresh_token";
     public static final String SAML_BEARER = "saml_bearer";
-    public static final String CLIENT_CREDENTIALS = "client_credentials";
-    public static final String AUTHORIZATION_CODE = "authorization_code";
     public static final String CLIENT_AUTHENTICATED_USER = "client_authenticated_user";
-    public static final String CACHE = "cache";
     public static final String CAPACITY = "capacity";
     public static final String OAUTH = "oauth";
     public static final String PATH_PREFIX_SERVICES = "pathPrefixServices";
     public static final String SERVICE_ID_AUTH_SERVERS = "serviceIdAuthServers";
-    public static final String KEY = "key";
     public static final String CLIENT_SECRET = "client_secret";
     public static final String ENABLE_HTTP2 = "enableHttp2";
     public static final String TIMEOUT = "timeout";
     public static final String MAX_REQUEST_RETRY = "maxRequestRetry";
     public static final String REQUEST_RETRY_DELAY = "requestRetryDelay";
-    public static final String TOKEN = "token";
     public static final int DEFAULT_BUFFER_SIZE = 24; // 24*1024 buffer size will be good for most of the app.
     public static final int DEFAULT_ERROR_THRESHOLD = 5;
     public static final int DEFAULT_TIMEOUT = 3000;
     public static final int DEFAULT_RESET_TIMEOUT = 600000;
-    public static final String TOKEN_RENEW_BEFORE_EXPIRED = "tokenRenewBeforeExpired";
-    public static final String EXPIRED_REFRESH_RETRY_DELAY = "expiredRefreshRetryDelay";
-    public static final String EARLY_REFRESH_RETRY_DELAY = "earlyRefreshRetryDelay";
+    public static final String ERROR_THRESHOLD = "errorThreshold";
+    public static final String RESET_TIMEOUT = "resetTimeout";
+    public static final String INJECT_OPEN_TRACING = "injectOpenTracing";
+    public static final String INJECT_CALLER_ID = "injectCallerId";
+    public static final String CONNECTION_POOL_SIZE = "connectionPoolSize";
+    public static final String CONNECTION_EXPIRE_TIME = "connectionExpireTime";
+    public static final String MAX_REQ_PER_CONN = "maxReqPerConn";
+    public static final String MAX_CONNECTION_NUM_PER_HOST = "maxConnectionNumPerHost";
+    public static final String MIN_CONNECTION_NUM_PER_HOST = "minConnectionNumPerHost";
+    public static final String VERIFY_HOSTNAME = "verifyHostname";
+    public static final String LOAD_DEFAULT_TRUST_STORE = "loadDefaultTrustStore";
+    public static final String LOAD_TRUST_STORE = "loadTrustStore";
+    public static final String TRUST_STORE = "trustStore";
+    public static final String TRUST_STORE_PASS = "trustStorePass";
+    public static final String LOAD_KEY_STORE = "loadKeyStore";
+    public static final String KEY_STORE = "keyStore";
+    public static final String KEY_STORE_PASS = "keyStorePass";
+    public static final String KEY_PASS = "keyPass";
+    public static final String DEFAULT_CERT_PASSWORD = "defaultCertPassword";
+    public static final String TLS_VERSION = "tlsVersion";
+    public static final String DEFAULT_GROUP_KEY = "defaultGroupKey";
+    public static final String TRUSTED_NAMES = "trustedNames";
 
     private final Config config;
     private Map<String, Object> mappedConfig;
 
     @ObjectField(
-            configFieldName = "tls",
+            configFieldName = ClientConfig.TLS,
             useSubObjectDefault = true,
             ref = TlsConfig.class,
             description = "Settings for TLS"
     )
-    private TlsConfig tls;
+    @JsonProperty(ClientConfig.TLS)
+    private TlsConfig tls = null;
 
     @ObjectField(
-            configFieldName = "oauth",
+            configFieldName = ClientConfig.OAUTH,
             useSubObjectDefault = true,
             ref = OAuthConfig.class,
             description = "Settings for OAuth2 server communication."
     )
-    private OAuthConfig oauthConfig;
+    @JsonProperty(ClientConfig.OAUTH)
+    private OAuthConfig oauthConfig = null;
 
     @MapField(
-            configFieldName = "pathPrefixServices",
-            externalizedKeyName = "pathPrefixServices",
+            configFieldName = ClientConfig.PATH_PREFIX_SERVICES,
+            externalizedKeyName = ClientConfig.PATH_PREFIX_SERVICES,
             valueType = String.class,
             externalized = true,
             description = "If you have multiple OAuth 2.0 providers and use path prefix to decide which OAuth 2.0 server\n" +
                     "to get the token or JWK. If two or more services have the same path, you must use serviceId in\n" +
                     "the request header to use the serviceId to find the OAuth 2.0 provider configuration."
     )
-    private Map<String, String> pathPrefixServices;
+    @JsonProperty(ClientConfig.PATH_PREFIX_SERVICES)
+    private Map<String, String> pathPrefixServices = null;
 
     @ObjectField(
-            configFieldName = "request",
+            configFieldName = ClientConfig.REQUEST,
             useSubObjectDefault = true,
             ref = RequestConfig.class,
             description = "Circuit breaker configuration for the client"
     )
-    private RequestConfig request;
+    @JsonProperty(ClientConfig.REQUEST)
+    private RequestConfig request = null;
 
     private static volatile ClientConfig instance;
 

--- a/client-config/src/main/java/com/networknt/client/OAuthConfig.java
+++ b/client-config/src/main/java/com/networknt/client/OAuthConfig.java
@@ -1,18 +1,16 @@
 package com.networknt.client;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.config.schema.BooleanField;
 import com.networknt.config.schema.ObjectField;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OAuthConfig {
 
-    public static final String TOKEN = "token";
-    public static final String MULTIPLE_AUTH_SERVERS = "multipleAuthServers";
-    public static final String DEREF = "deref";
-    public static final String SIGN = "sign";
-
     @BooleanField(
-            configFieldName = MULTIPLE_AUTH_SERVERS,
-            externalizedKeyName = MULTIPLE_AUTH_SERVERS,
+            configFieldName = ClientConfig.MULTIPLE_AUTH_SERVERS,
+            externalizedKeyName = ClientConfig.MULTIPLE_AUTH_SERVERS,
             externalized = true,
             description = "OAuth 2.0 token endpoint configuration\n" +
                     "If there are multiple oauth providers per serviceId, then we need to update this flag to true. " +
@@ -20,31 +18,35 @@ public class OAuthConfig {
                     "path prefix, we need to set up the pathPrefixServices " +
                     "below if there is no duplicated paths between services."
     )
-    private boolean multipleAuthServers;
+    @JsonProperty(ClientConfig.MULTIPLE_AUTH_SERVERS)
+    private Boolean multipleAuthServers = false;
 
     @ObjectField(
-            configFieldName = TOKEN,
+            configFieldName = ClientConfig.TOKEN,
             useSubObjectDefault = true,
             ref = OAuthTokenConfig.class
     )
-    private OAuthTokenConfig token;
+    @JsonProperty(ClientConfig.TOKEN)
+    private OAuthTokenConfig token = null;
 
     @ObjectField(
-            configFieldName = SIGN,
+            configFieldName = ClientConfig.SIGN,
             useSubObjectDefault = true,
             ref = OAuthSignKeyConfig.class,
             description = "Sign endpoint configuration"
     )
-    private OauthSignConfig sign;
+    @JsonProperty(ClientConfig.SIGN)
+    private OauthSignConfig sign = null;
 
     @ObjectField(
-            configFieldName = DEREF,
+            configFieldName = ClientConfig.DEREF,
             useSubObjectDefault = true,
             ref = OAuthDerefConfig.class,
             description = "de-ref by reference token to JWT token. " +
                     "It is separate service as it might be the external OAuth 2.0 provider."
     )
-    private OAuthDerefConfig deref;
+    @JsonProperty(ClientConfig.DEREF)
+    private OAuthDerefConfig deref = null;
 
     public boolean isMultipleAuthServers() {
         return multipleAuthServers;

--- a/client-config/src/main/java/com/networknt/client/OAuthDerefConfig.java
+++ b/client-config/src/main/java/com/networknt/client/OAuthDerefConfig.java
@@ -1,30 +1,25 @@
 package com.networknt.client;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.config.schema.BooleanField;
 import com.networknt.config.schema.IntegerField;
 import com.networknt.config.schema.StringField;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OAuthDerefConfig {
 
-    public static final String SERVER_URL = "server_url";
-    public static final String PROXY_HOST = "proxyHost";
-    public static final String PROXY_PORT = "proxyPort";
-    public static final String SERVICE_ID = "serviceId";
-    public static final String ENABLE_HTTP2 = "enableHttp2";
-    public static final String URI = "uri";
-    public static final String CLIENT_ID = "clientId";
-    public static final String CLIENT_SECRET = "clientSecret";
-
     @StringField(
-            configFieldName = SERVER_URL,
+            configFieldName = ClientConfig.SERVER_URL,
             externalizedKeyName = "derefServerUrl",
             externalized = true,
             description = "Token service server url, this might be different than the above token server url.\n" +
                     "The static url will be used if it is configured."
     )
-    private String server_url;
+    @JsonProperty(ClientConfig.SERVER_URL)
+    private String serverUrl = null;
 
     @StringField(
-            configFieldName = PROXY_HOST,
+            configFieldName = ClientConfig.PROXY_HOST,
             externalizedKeyName = "derefProxyHost",
             externalized = true,
             description = "For users who leverage SaaS OAuth 2.0 provider in the public cloud and has an internal\n" +
@@ -32,10 +27,11 @@ public class OAuthDerefConfig {
                     "here for the HTTPS traffic. This option is only working with server_url and serviceId\n" +
                     "below should be commented out. OAuth 2.0 services cannot be discovered if a proxy is used."
     )
-    private String proxyHost;
+    @JsonProperty(ClientConfig.PROXY_HOST)
+    private String proxyHost = null;
 
     @IntegerField(
-            configFieldName = PROXY_PORT,
+            configFieldName = ClientConfig.PROXY_PORT,
             externalizedKeyName = "derefProxyPort",
             min = 0,
             max = 65535,
@@ -46,64 +42,70 @@ public class OAuthDerefConfig {
                     "If proxyHost is available and proxyPort is missing, then\n" +
                     "the default value 443 is going to be used for the HTTP connection."
     )
-    private int proxyPort;
+    @JsonProperty(ClientConfig.PROXY_PORT)
+    private Integer proxyPort = null;
 
     @StringField(
-            configFieldName = SERVICE_ID,
+            configFieldName = ClientConfig.SERVICE_ID,
             externalizedKeyName = "derefServiceId",
             externalized = true,
             defaultValue = "com.networknt.oauth2-token-1.0.0",
             description = "token service unique id for OAuth 2.0 provider. " +
                     "Need for service lookup/discovery. It will be used if above server_url is not configured."
     )
-    private String serviceId;
+    @JsonProperty(ClientConfig.SERVICE_ID)
+    private String serviceId = "com.networknt.oauth2-token-1.0.0";
 
     @BooleanField(
-            configFieldName = ENABLE_HTTP2,
+            configFieldName = ClientConfig.ENABLE_HTTP2,
             externalizedKeyName = "derefEnableHttp2",
             defaultValue = true,
             externalized = true,
             description = "set to true if the oauth2 provider supports HTTP/2"
     )
-    private boolean enableHttp2;
+    @JsonProperty(ClientConfig.ENABLE_HTTP2)
+    private Boolean enableHttp2 = true;
 
     @StringField(
-            configFieldName = URI,
+            configFieldName = ClientConfig.URI,
             externalizedKeyName = "derefUri",
             externalized = true,
             defaultValue = "/oauth2/deref",
             description = "the path for the key distribution endpoint"
     )
-    private String uri;
+    @JsonProperty(ClientConfig.URI)
+    private String uri = "/oauth2/deref";
 
     @StringField(
-            configFieldName = CLIENT_ID,
+            configFieldName = ClientConfig.CLIENT_ID,
             externalizedKeyName = "derefClientId",
             externalized = true,
             defaultValue = "f7d42348-c647-4efb-a52d-4c5787421e72",
             description = "client_id used to access key distribution service. " +
                     "It can be the same client_id with token service or not."
     )
-    private char[] client_id;
+    @JsonProperty(ClientConfig.CLIENT_ID)
+    private char[] clientId = "f7d42348-c647-4efb-a52d-4c5787421e72".toCharArray();
 
     @StringField(
-            configFieldName = CLIENT_SECRET,
+            configFieldName = ClientConfig.CLIENT_SECRET,
             externalizedKeyName = "derefClientSecret",
             externalized = true,
             defaultValue = "f6h1FTI8Q3-7UScPZDzfXA",
             description = "client_secret for deref"
     )
-    private char[] client_secret;
+    @JsonProperty(ClientConfig.CLIENT_SECRET)
+    private char[] clientSecret = "f6h1FTI8Q3-7UScPZDzfXA".toCharArray();
 
-    public String getServer_url() {
-        return server_url;
+    public String getServerUrl() {
+        return serverUrl;
     }
 
     public String getProxyHost() {
         return proxyHost;
     }
 
-    public int getProxyPort() {
+    public Integer getProxyPort() {
         return proxyPort;
     }
 
@@ -111,7 +113,7 @@ public class OAuthDerefConfig {
         return serviceId;
     }
 
-    public boolean isEnableHttp2() {
+    public Boolean isEnableHttp2() {
         return enableHttp2;
     }
 
@@ -119,11 +121,11 @@ public class OAuthDerefConfig {
         return uri;
     }
 
-    public char[] getClient_id() {
-        return client_id;
+    public char[] getClientId() {
+        return clientId;
     }
 
     public char[] getClient_secret() {
-        return client_secret;
+        return clientSecret;
     }
 }

--- a/client-config/src/main/java/com/networknt/client/OAuthSignKeyConfig.java
+++ b/client-config/src/main/java/com/networknt/client/OAuthSignKeyConfig.java
@@ -1,84 +1,87 @@
 package com.networknt.client;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.config.schema.BooleanField;
 import com.networknt.config.schema.StringField;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OAuthSignKeyConfig  {
 
-    public static final String SERVER_URL = "server_url";
-    public static final String SERVICE_ID = "serviceId";
-    public static final String URI = "uri";
-    public static final String CLIENT_ID = "client_id";
-    public static final String CLIENT_SECRET = "client_secret";
-    public static final String ENABLE_HTTP_2 = "enableHttp2";
-    public static final String AUDIENCE = "audience";
     @StringField(
-            configFieldName = SERVER_URL,
+            configFieldName = ClientConfig.SERVER_URL,
             externalizedKeyName = "signKeyServerUrl",
             externalized = true,
             description = "key distribution server url. It will be used to establish connection if it exists.\n" +
                     "if it is not set, then a service lookup against serviceId will be taken to discover an instance."
     )
-    private String server_url;
+    @JsonProperty(ClientConfig.SERVER_URL)
+    private String serverUrl;
 
     @StringField(
-            configFieldName = SERVICE_ID,
+            configFieldName = ClientConfig.SERVICE_ID,
             externalizedKeyName = "signKeyServiceId",
             externalized = true,
             defaultValue = "com.networknt.oauth2-key-1.0.0",
             description = "the unique service id for key distribution service, " +
                     "it will be used to lookup key service if above url doesn't exist."
     )
-    private String serviceId;
+    @JsonProperty(ClientConfig.SERVICE_ID)
+    private String serviceId = "com.networknt.oauth2-key-1.0.0";
 
     @StringField(
-            configFieldName = URI,
+            configFieldName = ClientConfig.URI,
             externalizedKeyName = "signKeyUri",
             externalized = true,
             defaultValue = "/oauth2/key",
             description = "the path for the key distribution endpoint"
     )
-    private String uri;
+    @JsonProperty(ClientConfig.URI)
+    private String uri = "/oauth2/key";
 
     @StringField(
-            configFieldName = CLIENT_ID,
+            configFieldName = ClientConfig.CLIENT_ID,
             externalizedKeyName = "signKeyClientId",
             externalized = true,
             defaultValue = "f7d42348-c647-4efb-a52d-4c5787421e72",
             description = "client_id used to access key distribution service. " +
                     "It can be the same client_id with token service or not."
     )
-    private char[] client_id;
+    @JsonProperty(ClientConfig.CLIENT_ID)
+    private char[] clientId = "f7d42348-c647-4efb-a52d-4c5787421e72".toCharArray();
 
     @StringField(
-            configFieldName = CLIENT_SECRET,
+            configFieldName = ClientConfig.CLIENT_SECRET,
             externalizedKeyName = "signKeyClientSecret",
             externalized = true,
             defaultValue = "f6h1FTI8Q3-7UScPZDzfXA",
             description = "client secret used to access the key distribution service."
     )
+    @JsonProperty(ClientConfig.CLIENT_SECRET)
     private char[] client_secret;
 
     @BooleanField(
-            configFieldName = ENABLE_HTTP_2,
+            configFieldName = ClientConfig.ENABLE_HTTP_2,
             externalizedKeyName = "signKeyEnableHttp2",
             defaultValue = true,
             externalized = true,
             description = "set to true if the oauth2 provider supports HTTP/2"
     )
-    private boolean enableHttp2;
+    @JsonProperty(ClientConfig.ENABLE_HTTP_2)
+    private Boolean enableHttp2 = true;
 
     @StringField(
-            configFieldName = AUDIENCE,
+            configFieldName = ClientConfig.AUDIENCE,
             externalizedKeyName = "signKeyAudience",
             externalized = true,
             description = "audience for the token validation. " +
                     "It is optional and if it is not configured, no audience validation will be executed."
     )
+    @JsonProperty(ClientConfig.AUDIENCE)
     private String audience;
 
-    public String getServer_url() {
-        return server_url;
+    public String getServerUrl() {
+        return serverUrl;
     }
 
     public String getServiceId() {
@@ -89,15 +92,15 @@ public class OAuthSignKeyConfig  {
         return uri;
     }
 
-    public char[] getClient_id() {
-        return client_id;
+    public char[] getClientId() {
+        return clientId;
     }
 
     public char[] getClient_secret() {
         return client_secret;
     }
 
-    public boolean isEnableHttp2() {
+    public Boolean isEnableHttp2() {
         return enableHttp2;
     }
 

--- a/client-config/src/main/java/com/networknt/client/OAuthTokenAuthorizationCodeConfig.java
+++ b/client-config/src/main/java/com/networknt/client/OAuthTokenAuthorizationCodeConfig.java
@@ -1,55 +1,57 @@
 package com.networknt.client;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.config.schema.ArrayField;
 import com.networknt.config.schema.StringField;
 
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OAuthTokenAuthorizationCodeConfig {
 
-    public static final String URI = "uri";
-    public static final String CLIENT_ID = "client_id";
-    public static final String CLIENT_SECRET = "client_secret";
-    public static final String REDIRECT_URI = "redirect_uri";
-    public static final String SCOPE = "scope";
     @StringField(
-            configFieldName = URI,
+            configFieldName = ClientConfig.URI,
             externalizedKeyName = "tokenAcUri",
             externalized = true,
             defaultValue = "/oauth2/token",
             description = "token endpoint for authorization code grant"
     )
-    private String uri;
+    @JsonProperty(ClientConfig.URI)
+    private String uri = "/oauth2/token";
 
     @StringField(
-            configFieldName = CLIENT_ID,
+            configFieldName = ClientConfig.CLIENT_ID,
             externalizedKeyName = "tokenAcClientId",
             externalized = true,
             defaultValue = "f7d42348-c647-4efb-a52d-4c5787421e72",
             description = "client_id for authorization code grant flow."
     )
-    private char[] client_id;
+    @JsonProperty(ClientConfig.CLIENT_ID)
+    private char[] clientId = "f7d42348-c647-4efb-a52d-4c5787421e72".toCharArray();
 
     @StringField(
-            configFieldName = CLIENT_SECRET,
+            configFieldName = ClientConfig.CLIENT_SECRET,
             externalizedKeyName = "tokenAcClientSecret",
             externalized = true,
             defaultValue = "f6h1FTI8Q3-7UScPZDzfXA",
             description = "client_secret for authorization code grant flow."
     )
-    private char[] client_secret;
+    @JsonProperty(ClientConfig.CLIENT_SECRET)
+    private char[] clientSecret = "f6h1FTI8Q3-7UScPZDzfXA".toCharArray();
 
     @StringField(
-            configFieldName = REDIRECT_URI,
+            configFieldName = ClientConfig.REDIRECT_URI,
             externalizedKeyName = "tokenAcRedirectUri",
             externalized = true,
             defaultValue = "https://localhost:3000/authorization",
             description = "the web server uri that will receive the redirected authorization code"
     )
-    private String redirect_uri;
+    @JsonProperty(ClientConfig.REDIRECT_URI)
+    private String redirectUri = "https://localhost:3000/authorization";
 
     @ArrayField(
-            configFieldName = SCOPE,
+            configFieldName = ClientConfig.SCOPE,
             externalizedKeyName = "tokenAcScope",
             externalized = true,
             items = String.class,
@@ -59,22 +61,23 @@ public class OAuthTokenAuthorizationCodeConfig {
                     "- petstore.r\n" +
                     "- petstore.w\n"
     )
-    private List<String> scope;
+    @JsonProperty(ClientConfig.SCOPE)
+    private List<String> scope = null;
 
     public String getUri() {
         return uri;
     }
 
-    public char[] getClient_id() {
-        return client_id;
+    public char[] getClientId() {
+        return clientId;
     }
 
-    public char[] getClient_secret() {
-        return client_secret;
+    public char[] getClientSecret() {
+        return clientSecret;
     }
 
-    public String getRedirect_uri() {
-        return redirect_uri;
+    public String getRedirectUri() {
+        return redirectUri;
     }
 
     public List<String> getScope() {

--- a/client-config/src/main/java/com/networknt/client/OAuthTokenClientCredentialConfig.java
+++ b/client-config/src/main/java/com/networknt/client/OAuthTokenClientCredentialConfig.java
@@ -1,5 +1,7 @@
 package com.networknt.client;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.config.schema.ArrayField;
 import com.networknt.config.schema.MapField;
 import com.networknt.config.schema.StringField;
@@ -7,44 +9,41 @@ import com.networknt.config.schema.StringField;
 import java.util.List;
 import java.util.Map;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OAuthTokenClientCredentialConfig {
 
-
-    public static final String URI = "uri";
-    public static final String CLIENT_ID = "client_id";
-    public static final String CLIENT_SECRET = "client_secret";
-    public static final String SCOPE = "scope";
-    public static final String SERVICE_ID_AUTH_SERVERS = "serviceIdAuthServers";
-
     @StringField(
-            configFieldName = URI,
+            configFieldName = ClientConfig.URI,
             externalizedKeyName = "tokenCcUri",
             externalized = true,
             defaultValue = "/oauth2/token",
             description = "token endpoint for client credentials grant"
     )
-    private String uri;
+    @JsonProperty(ClientConfig.URI)
+    private String uri = "/oauth2/token";
 
     @StringField(
-            configFieldName = CLIENT_ID,
+            configFieldName = ClientConfig.CLIENT_ID,
             externalizedKeyName = "tokenCcClientId",
             externalized = true,
             defaultValue = "f7d42348-c647-4efb-a52d-4c5787421e72",
             description = "client_id for client credentials grant flow."
     )
-    private char[] client_id;
+    @JsonProperty(ClientConfig.CLIENT_ID)
+    private char[] clientId = "f7d42348-c647-4efb-a52d-4c5787421e72".toCharArray();
 
     @StringField(
-            configFieldName = CLIENT_SECRET,
+            configFieldName = ClientConfig.CLIENT_SECRET,
             externalizedKeyName = "tokenCcClientSecret",
             externalized = true,
             defaultValue = "f6h1FTI8Q3-7UScPZDzfXA",
             description = "client_secret for client credentials grant flow."
     )
-    private char[] client_secret;
+    @JsonProperty(ClientConfig.CLIENT_SECRET)
+    private char[] clientSecret = "f6h1FTI8Q3-7UScPZDzfXA".toCharArray();
 
     @ArrayField(
-            configFieldName = SCOPE,
+            configFieldName = ClientConfig.SCOPE,
             externalizedKeyName = "tokenCcScope",
             externalized = true,
             items = String.class,
@@ -54,10 +53,11 @@ public class OAuthTokenClientCredentialConfig {
                     "- petstore.r\n" +
                     "- petstore.w\n"
     )
-    private List<String> scope;
+    @JsonProperty(ClientConfig.SCOPE)
+    private List<String> scope = null;
 
     @MapField(
-            configFieldName = SERVICE_ID_AUTH_SERVERS,
+            configFieldName = ClientConfig.SERVICE_ID_AUTH_SERVERS,
             externalizedKeyName = "tokenCcServiceIdAuthServers",
             valueType = AuthServerConfig.class,
             externalized = true,
@@ -65,18 +65,19 @@ public class OAuthTokenClientCredentialConfig {
                     "Used only when multipleOAuthServer is\n" +
                     "set as true. For detailed config options, please see the values.yml in the client module test."
     )
-    private Map<String, AuthServerConfig> serviceIdAuthServers;
+    @JsonProperty(ClientConfig.SERVICE_ID_AUTH_SERVERS)
+    private Map<String, AuthServerConfig> serviceIdAuthServers = null;
 
     public String getUri() {
         return uri;
     }
 
-    public char[] getClient_id() {
-        return client_id;
+    public char[] getClientId() {
+        return clientId;
     }
 
-    public char[] getClient_secret() {
-        return client_secret;
+    public char[] getClientSecret() {
+        return clientSecret;
     }
 
     public List<String> getScope() {

--- a/client-config/src/main/java/com/networknt/client/OAuthTokenConfig.java
+++ b/client-config/src/main/java/com/networknt/client/OAuthTokenConfig.java
@@ -1,80 +1,76 @@
 package com.networknt.client;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.config.schema.BooleanField;
 import com.networknt.config.schema.IntegerField;
 import com.networknt.config.schema.ObjectField;
 import com.networknt.config.schema.StringField;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OAuthTokenConfig  {
 
-    public static final String CACHE = "cache";
-    public static final String TOKEN_RENEW_BEFORE_EXPIRED = "tokenRenewBeforeExpired";
-    public static final String EXPIRED_REFRESH_RETRY_DELAY = "expiredRefreshRetryDelay";
-    public static final String EARLY_REFRESH_RETRY_DELAY = "earlyRefreshRetryDelay";
-    public static final String SERVER_URL = "server_url";
-    public static final String SERVICE_ID = "serviceId";
-    public static final String PROXY_HOST = "proxyHost";
-    public static final String PROXY_PORT = "proxyPort";
-    public static final String ENABLE_HTTP_2 = "enableHttp2";
-    public static final String AUTHORIZATION_CODE = "authorization_code";
-    public static final String CLIENT_CREDENTIALS = "client_credentials";
-    public static final String REFRESH_TOKEN = "refresh_token";
-    public static final String KEY = "key";
     @ObjectField(
-            configFieldName = CACHE,
+            configFieldName = ClientConfig.CACHE,
             useSubObjectDefault = true,
             ref = OauthTokenCacheConfig.class
     )
-    private OauthTokenCacheConfig cache;
+    @JsonProperty(ClientConfig.CACHE)
+    private OauthTokenCacheConfig cache = null;
 
     @IntegerField(
-            configFieldName = TOKEN_RENEW_BEFORE_EXPIRED,
-            externalizedKeyName = TOKEN_RENEW_BEFORE_EXPIRED,
+            configFieldName = ClientConfig.TOKEN_RENEW_BEFORE_EXPIRED,
+            externalizedKeyName = ClientConfig.TOKEN_RENEW_BEFORE_EXPIRED,
             externalized = true,
             defaultValue = 60000,
             description = "The scope token will be renewed automatically 1 minute before expiry"
     )
-    private int tokenRenewBeforeExpired;
+    @JsonProperty(ClientConfig.TOKEN_RENEW_BEFORE_EXPIRED)
+    private Integer tokenRenewBeforeExpired = 60000;
 
     @IntegerField(
-            configFieldName = EXPIRED_REFRESH_RETRY_DELAY,
-            externalizedKeyName = EXPIRED_REFRESH_RETRY_DELAY,
+            configFieldName = ClientConfig.EXPIRED_REFRESH_RETRY_DELAY,
+            externalizedKeyName = ClientConfig.EXPIRED_REFRESH_RETRY_DELAY,
             externalized = true,
             defaultValue = 2000,
             description = "if scope token is expired, we need short delay so that we can retry faster."
     )
-    private int expiredRefreshRetryDelay;
+    @JsonProperty(ClientConfig.EXPIRED_REFRESH_RETRY_DELAY)
+    private Integer expiredRefreshRetryDelay = 2000;
 
     @IntegerField(
-            configFieldName = EARLY_REFRESH_RETRY_DELAY,
-            externalizedKeyName = EARLY_REFRESH_RETRY_DELAY,
+            configFieldName = ClientConfig.EARLY_REFRESH_RETRY_DELAY,
+            externalizedKeyName = ClientConfig.EARLY_REFRESH_RETRY_DELAY,
             externalized = true,
             defaultValue = 4000,
             description = "if scope token is not expired but in renew window, we need slow retry delay."
     )
-    private int earlyRefreshRetryDelay;
+    @JsonProperty(ClientConfig.EARLY_REFRESH_RETRY_DELAY)
+    private Integer earlyRefreshRetryDelay = 4000;
 
     @StringField(
-            configFieldName = SERVER_URL,
+            configFieldName = ClientConfig.SERVER_URL,
             externalizedKeyName = "tokenServerUrl",
             externalized = true,
             description = "token server url. The default port number for token service is 6882. If this is set,\n" +
                     "it will take high priority than serviceId for the direct connection"
     )
-    private String server_url;
+    @JsonProperty(ClientConfig.SERVER_URL)
+    private String serverUrl = null;
 
     @StringField(
-            configFieldName = SERVICE_ID,
+            configFieldName = ClientConfig.SERVICE_ID,
             externalizedKeyName = "tokenServiceId",
             externalized = true,
             defaultValue = "com.networknt.oauth2-token-1.0.0",
             description = "token service unique id for OAuth 2.0 provider. If server_url is not set above,\n" +
                     "a service discovery action will be taken to find an instance of token service."
     )
-    private String serviceId;
+    @JsonProperty(ClientConfig.SERVICE_ID)
+    private String serviceId = "com.networknt.oauth2-token-1.0.0";
 
     @StringField(
-            configFieldName = PROXY_HOST,
+            configFieldName = ClientConfig.PROXY_HOST,
             externalizedKeyName = "tokenProxyHost",
             externalized = true,
             description = "For users who leverage SaaS OAuth 2.0 provider from lightapi.net or others in the public cloud\n" +
@@ -82,10 +78,11 @@ public class OAuthTokenConfig  {
                     "proxyHost here for the HTTPS traffic. This option is only working with server_url and serviceId\n" +
                     "below should be commented out. OAuth 2.0 services cannot be discovered if a proxy server is used."
     )
-    private String proxyHost;
+    @JsonProperty(ClientConfig.PROXY_HOST)
+    private String proxyHost = null;
 
     @IntegerField(
-            configFieldName = PROXY_PORT,
+            configFieldName = ClientConfig.PROXY_PORT,
             externalizedKeyName = "tokenProxyPort",
             min = 0,
             max = 65535,
@@ -94,66 +91,72 @@ public class OAuthTokenConfig  {
                     "a different port, please specify it here. If proxyHost is available and proxyPort is missing, then\n" +
                     "the default value 443 is going to be used for the HTTP connection."
     )
-    private int proxyPort;
+    @JsonProperty(ClientConfig.PROXY_PORT)
+    private Integer proxyPort = null;
 
     @BooleanField(
-            configFieldName = ENABLE_HTTP_2,
+            configFieldName = ClientConfig.ENABLE_HTTP_2,
             externalizedKeyName = "tokenEnableHttp2",
             defaultValue = true,
             externalized = true,
             description = "set to true if the oauth2 provider supports HTTP/2"
     )
-    private boolean enableHttp2;
+    @JsonProperty(ClientConfig.ENABLE_HTTP_2)
+    private Boolean enableHttp2 = true;
 
     @ObjectField(
-            configFieldName = AUTHORIZATION_CODE,
+            configFieldName = ClientConfig.AUTHORIZATION_CODE,
             useSubObjectDefault = true,
             ref = OAuthTokenAuthorizationCodeConfig.class,
             description = "the following section defines uri and parameters for authorization code grant type"
     )
-    private OAuthTokenAuthorizationCodeConfig authorization_code;
+    @JsonProperty(ClientConfig.AUTHORIZATION_CODE)
+    private OAuthTokenAuthorizationCodeConfig authorizationCode = null;
 
     @ObjectField(
-            configFieldName = CLIENT_CREDENTIALS,
+            configFieldName = ClientConfig.CLIENT_CREDENTIALS,
             useSubObjectDefault = true,
             ref = OAuthTokenClientCredentialConfig.class,
             description = "the following section defines uri and parameters for client credentials grant type"
     )
-    private OAuthTokenClientCredentialConfig client_credentials;
+    @JsonProperty(ClientConfig.CLIENT_CREDENTIALS)
+    private OAuthTokenClientCredentialConfig clientCredentials = null;
 
     @ObjectField(
-            configFieldName = REFRESH_TOKEN,
+            configFieldName = ClientConfig.REFRESH_TOKEN,
             useSubObjectDefault = true,
             ref = OAuthTokenRefreshTokenConfig.class
     )
-    private OAuthTokenRefreshTokenConfig refresh_token;
+    @JsonProperty(ClientConfig.REFRESH_TOKEN)
+    private OAuthTokenRefreshTokenConfig refreshToken = null;
 
     @ObjectField(
-            configFieldName = KEY,
+            configFieldName = ClientConfig.KEY,
             useSubObjectDefault = true,
             ref = OAuthTokenKeyConfig.class,
             description = "light-oauth2 key distribution endpoint configuration for token verification"
     )
-    private OAuthTokenKeyConfig key;
+    @JsonProperty(ClientConfig.KEY)
+    private OAuthTokenKeyConfig key = null;
 
     public OauthTokenCacheConfig getCache() {
         return cache;
     }
 
-    public int getTokenRenewBeforeExpired() {
+    public Integer getTokenRenewBeforeExpired() {
         return tokenRenewBeforeExpired;
     }
 
-    public int getExpiredRefreshRetryDelay() {
+    public Integer getExpiredRefreshRetryDelay() {
         return expiredRefreshRetryDelay;
     }
 
-    public int getEarlyRefreshRetryDelay() {
+    public Integer getEarlyRefreshRetryDelay() {
         return earlyRefreshRetryDelay;
     }
 
-    public String getServer_url() {
-        return server_url;
+    public String getServerUrl() {
+        return serverUrl;
     }
 
     public String getServiceId() {
@@ -164,24 +167,24 @@ public class OAuthTokenConfig  {
         return proxyHost;
     }
 
-    public int getProxyPort() {
+    public Integer getProxyPort() {
         return proxyPort;
     }
 
-    public boolean isEnableHttp2() {
+    public Boolean isEnableHttp2() {
         return enableHttp2;
     }
 
-    public OAuthTokenAuthorizationCodeConfig getAuthorization_code() {
-        return authorization_code;
+    public OAuthTokenAuthorizationCodeConfig getAuthorizationCode() {
+        return authorizationCode;
     }
 
-    public OAuthTokenClientCredentialConfig getClient_credentials() {
-        return client_credentials;
+    public OAuthTokenClientCredentialConfig getClientCredentials() {
+        return clientCredentials;
     }
 
     public OAuthTokenRefreshTokenConfig getRefresh_token() {
-        return refresh_token;
+        return refreshToken;
     }
 
     public OAuthTokenKeyConfig getKey() {

--- a/client-config/src/main/java/com/networknt/client/OAuthTokenKeyConfig.java
+++ b/client-config/src/main/java/com/networknt/client/OAuthTokenKeyConfig.java
@@ -1,78 +1,79 @@
 package com.networknt.client;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.config.schema.BooleanField;
 import com.networknt.config.schema.MapField;
 import com.networknt.config.schema.StringField;
 
 import java.util.Map;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OAuthTokenKeyConfig {
 
-    public static final String SERVER_URL = "server_url";
-    public static final String SERVICE_ID = "serviceId";
-    public static final String URI = "uri";
-    public static final String CLIENT_ID = "client_id";
-    public static final String CLIENT_SECRET = "client_secret";
-    public static final String ENABLE_HTTP_2 = "enableHttp2";
-    public static final String SERVICE_ID_AUTH_SERVERS = "serviceIdAuthServers";
-    public static final String AUDIENCE = "audience";
     @StringField(
-            configFieldName = SERVER_URL,
+            configFieldName = ClientConfig.SERVER_URL,
             externalizedKeyName = "tokenKeyServerUrl",
             externalized = true,
             description = "key distribution server url for token verification. It will be used if it is configured.\n" +
                     "If it is not set, a service lookup will be taken with serviceId to find an instance"
     )
-    private String server_url;
+    @JsonProperty(ClientConfig.SERVER_URL)
+    private String serverUrl = null;
 
     @StringField(
-            configFieldName = SERVICE_ID,
+            configFieldName = ClientConfig.SERVICE_ID,
             externalizedKeyName = "tokenKeyServiceId",
             externalized = true,
             defaultValue = "com.networknt.oauth2-key-1.0.0",
             description = "key serviceId for key distribution service, " +
                     "it will be used if above server_url is not configured."
     )
-    private String serviceId;
+    @JsonProperty(ClientConfig.SERVICE_ID)
+    private String serviceId = "com.networknt.oauth2-key-1.0.0";
 
     @StringField(
-            configFieldName = URI,
+            configFieldName = ClientConfig.URI,
             externalizedKeyName = "tokenKeyUri",
             externalized = true,
             defaultValue = "/oauth2/key",
             description = "the path for the key distribution endpoint"
     )
-    private String uri;
+    @JsonProperty(ClientConfig.URI)
+    private String uri = "/oauth2/key";
 
     @StringField(
-            configFieldName = CLIENT_ID,
+            configFieldName = ClientConfig.CLIENT_ID,
             externalizedKeyName = "tokenKeyClientId",
             externalized = true,
             defaultValue = "f7d42348-c647-4efb-a52d-4c5787421e72",
             description = "client_id used to access key distribution service. " +
                     "It can be the same client_id with token service or not."
     )
-    private char[] client_id;
+    @JsonProperty(ClientConfig.CLIENT_ID)
+    private char[] clientId = "f7d42348-c647-4efb-a52d-4c5787421e72".toCharArray();
 
     @StringField(
-            configFieldName = CLIENT_SECRET,
+            configFieldName = ClientConfig.CLIENT_SECRET,
             externalizedKeyName = "tokenKeyClientSecret",
             externalized = true,
             defaultValue = "f6h1FTI8Q3-7UScPZDzfXA",
             description = "client secret used to access the key distribution service."
     )
-    private char[] client_secret;
+    @JsonProperty(ClientConfig.CLIENT_SECRET)
+    private char[] clientSecret = "f6h1FTI8Q3-7UScPZDzfXA".toCharArray();
 
     @BooleanField(
-            configFieldName = ENABLE_HTTP_2,
+            configFieldName = ClientConfig.ENABLE_HTTP_2,
             externalizedKeyName = "tokenKeyEnableHttp2",
             defaultValue = true,
             externalized = true,
             description = "set to true if the oauth2 provider supports HTTP/2"
     )
-    private boolean enableHttp2;
+    @JsonProperty(ClientConfig.ENABLE_HTTP2)
+    private Boolean enableHttp2 = true;
 
     @MapField(
-            configFieldName = SERVICE_ID_AUTH_SERVERS,
+            configFieldName = ClientConfig.SERVICE_ID_AUTH_SERVERS,
             externalizedKeyName = "tokenKeyServiceIdAuthServers",
             valueType = AuthServerConfig.class,
             externalized = true,
@@ -80,19 +81,21 @@ public class OAuthTokenKeyConfig {
                     "Used only when multipleOAuthServer is\n" +
                     "set as true. For detailed config options, please see the values.yml in the client module test."
     )
-    private Map<String, AuthServerConfig> serviceIdAuthServers;
+    @JsonProperty(ClientConfig.SERVICE_ID_AUTH_SERVERS)
+    private Map<String, AuthServerConfig> serviceIdAuthServers = null;
 
     @StringField(
-            configFieldName = AUDIENCE,
+            configFieldName = ClientConfig.AUDIENCE,
             externalizedKeyName = "tokenKeyAudience",
             externalized = true,
             description = "audience for the token validation. " +
                     "It is optional and if it is not configured, no audience validation will be executed."
     )
-    private String audience;
+    @JsonProperty(ClientConfig.AUDIENCE)
+    private String audience = null;
 
-    public String getServer_url() {
-        return server_url;
+    public String getServerUrl() {
+        return serverUrl;
     }
 
     public String getServiceId() {
@@ -103,15 +106,15 @@ public class OAuthTokenKeyConfig {
         return uri;
     }
 
-    public char[] getClient_id() {
-        return client_id;
+    public char[] getClientId() {
+        return clientId;
     }
 
-    public char[] getClient_secret() {
-        return client_secret;
+    public char[] getClientSecret() {
+        return clientSecret;
     }
 
-    public boolean isEnableHttp2() {
+    public Boolean isEnableHttp2() {
         return enableHttp2;
     }
 

--- a/client-config/src/main/java/com/networknt/client/OAuthTokenRefreshTokenConfig.java
+++ b/client-config/src/main/java/com/networknt/client/OAuthTokenRefreshTokenConfig.java
@@ -1,46 +1,47 @@
 package com.networknt.client;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.config.schema.ArrayField;
 import com.networknt.config.schema.StringField;
 
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OAuthTokenRefreshTokenConfig {
 
-    public static final String URI = "uri";
-    public static final String CLIENT_ID = "client_id";
-    public static final String CLIENT_SECRET = "client_secret";
-    public static final String SCOPE = "scope";
-
     @StringField(
-            configFieldName = URI,
+            configFieldName = ClientConfig.URI,
             externalizedKeyName = "tokenRtUri",
             externalized = true,
             defaultValue = "/oauth2/token",
             description = "token endpoint for refresh token grant"
     )
-    private String uri;
+    @JsonProperty(ClientConfig.URI)
+    private String uri = "/oauth2/token";
 
     @StringField(
-            configFieldName = CLIENT_ID,
+            configFieldName = ClientConfig.CLIENT_ID,
             externalizedKeyName = "tokenRtClientId",
             externalized = true,
             defaultValue = "f7d42348-c647-4efb-a52d-4c5787421e72",
             description = "client_id for refresh token grant flow."
     )
-    private char[] client_id;
+    @JsonProperty(ClientConfig.CLIENT_ID)
+    private char[] clientId = "f7d42348-c647-4efb-a52d-4c5787421e72".toCharArray();
 
     @StringField(
-            configFieldName = CLIENT_SECRET,
+            configFieldName = ClientConfig.CLIENT_SECRET,
             externalizedKeyName = "tokenRtClientSecret",
             externalized = true,
             defaultValue = "f6h1FTI8Q3-7UScPZDzfXA",
             description = "client_secret for refresh token grant flow"
     )
-    private char[] client_secret;
+    @JsonProperty(ClientConfig.CLIENT_SECRET)
+    private char[] clientSecret = "f6h1FTI8Q3-7UScPZDzfXA".toCharArray();
 
     @ArrayField(
-            configFieldName = SCOPE,
+            configFieldName = ClientConfig.SCOPE,
             externalizedKeyName = "tokenRtScope",
             externalized = true,
             items = String.class,
@@ -51,18 +52,19 @@ public class OAuthTokenRefreshTokenConfig {
                     "- petstore.w\n"
 
     )
-    private List<String> scope;
+    @JsonProperty(ClientConfig.SCOPE)
+    private List<String> scope = null;
 
     public String getUri() {
         return uri;
     }
 
-    public char[] getClient_id() {
-        return client_id;
+    public char[] getClientId() {
+        return clientId;
     }
 
-    public char[] getClient_secret() {
-        return client_secret;
+    public char[] getClientSecret() {
+        return clientSecret;
     }
 
     public List<String> getScope() {

--- a/client-config/src/main/java/com/networknt/client/OauthSignConfig.java
+++ b/client-config/src/main/java/com/networknt/client/OauthSignConfig.java
@@ -1,35 +1,28 @@
 package com.networknt.client;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.config.schema.BooleanField;
 import com.networknt.config.schema.IntegerField;
 import com.networknt.config.schema.ObjectField;
 import com.networknt.config.schema.StringField;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OauthSignConfig {
 
-    public static final String SERVER_URL = "server_url";
-    public static final String PROXY_HOST = "proxyHost";
-    public static final String PROXY_PORT = "proxyPort";
-    public static final String SERVICE_ID = "serviceId";
-    public static final String URI = "uri";
-    public static final String TIMEOUT = "timeout";
-    public static final String ENABLE_HTTP_2 = "enableHttp2";
-    public static final String CLIENT_ID = "client_id";
-    public static final String CLIENT_SECRET = "client_secret";
-    public static final String KEY = "key";
-
     @StringField(
-            configFieldName = SERVER_URL,
+            configFieldName = ClientConfig.SERVER_URL,
             externalizedKeyName = "signServerUrl",
             externalized = true,
             description = "token server url. The default port number for token service is 6882. " +
                     "If this url exists, it will be used.\n" +
                     "if it is not set, then a service lookup against serviceId will be taken to discover an instance."
     )
-    private String server_url;
+    @JsonProperty(ClientConfig.SERVER_URL)
+    private String serverUrl = null;
 
     @StringField(
-            configFieldName = PROXY_HOST,
+            configFieldName = ClientConfig.PROXY_HOST,
             externalizedKeyName = "signProxyHost",
             externalized = true,
             description = "For users who leverage SaaS OAuth 2.0 provider from lightapi.net or others in the public cloud\n" +
@@ -37,10 +30,11 @@ public class OauthSignConfig {
                     "proxyHost here for the HTTPS traffic. This option is only working with server_url and serviceId\n" +
                     "below should be commented out. OAuth 2.0 services cannot be discovered if a proxy server is used."
     )
-    private String proxyHost;
+    @JsonProperty(ClientConfig.PROXY_HOST)
+    private String proxyHost = null;
 
     @IntegerField(
-            configFieldName = PROXY_PORT,
+            configFieldName = ClientConfig.PROXY_PORT,
             externalizedKeyName = "signProxyPort",
             min = 0,
             max = 65535,
@@ -49,81 +43,89 @@ public class OauthSignConfig {
                     "a different port, please specify it here. If proxyHost is available and proxyPort is missing, then\n" +
                     "the default value 443 is going to be used for the HTTP connection."
     )
-    private int proxyPort;
+    @JsonProperty(ClientConfig.PROXY_PORT)
+    private Integer proxyPort = null;
 
     @StringField(
-            configFieldName = SERVICE_ID,
+            configFieldName = ClientConfig.SERVICE_ID,
             externalizedKeyName = "signServiceId",
             externalized = true,
             defaultValue = "com.networknt.oauth2-token-1.0.0",
             description = "token serviceId. If server_url doesn't exist, " +
                     "the serviceId will be used to lookup the token service."
     )
-    private String serviceId;
+    @JsonProperty(ClientConfig.SERVICE_ID)
+    private String serviceId = "com.networknt.oauth2-token-1.0.0";
 
     @StringField(
-            configFieldName = URI,
+            configFieldName = ClientConfig.URI,
             externalizedKeyName = "signUri",
             externalized = true,
             defaultValue = "/oauth2/token",
             description = "signing endpoint for the sign request"
     )
-    private String uri;
+    @JsonProperty(ClientConfig.URI)
+    private String uri = "/oauth2/sign";
 
     @IntegerField(
-            configFieldName = TIMEOUT,
+            configFieldName = ClientConfig.TIMEOUT,
             externalizedKeyName = "signTimeout",
             externalized = true,
             defaultValue = 2000,
             description = "timeout in milliseconds"
     )
-    private int timeout;
+    @JsonProperty(ClientConfig.TIMEOUT)
+    private Integer timeout = 2000;
 
     @BooleanField(
-            configFieldName = ENABLE_HTTP_2,
+            configFieldName = ClientConfig.ENABLE_HTTP_2,
             externalizedKeyName = "signEnableHttp2",
             defaultValue = true,
             externalized = true,
             description = "set to true if the oauth2 provider supports HTTP/2"
     )
-    private boolean enableHttp2;
+    @JsonProperty(ClientConfig.ENABLE_HTTP_2)
+    private boolean enableHttp2 = true;
 
     @StringField(
-            configFieldName = CLIENT_ID,
+            configFieldName = ClientConfig.CLIENT_ID,
             externalizedKeyName = "signClientId",
             externalized = true,
             defaultValue = "f7d42348-c647-4efb-a52d-4c5787421e72",
             description = "client_id for client authentication"
     )
-    private char[] client_id;
+    @JsonProperty(ClientConfig.CLIENT_ID)
+    private char[] clientId =  "f7d42348-c647-4efb-a52d-4c5787421e72".toCharArray();
 
     @StringField(
-            configFieldName = CLIENT_SECRET,
+            configFieldName = ClientConfig.CLIENT_SECRET,
             externalizedKeyName = "signClientSecret",
             externalized = true,
             defaultValue = "f6h1FTI8Q3-7UScPZDzfXA",
             description = "client secret for client authentication and it can be encrypted here."
     )
-    private char[] client_secret;
+    @JsonProperty(ClientConfig.CLIENT_SECRET)
+    private char[] clientSecret = "f6h1FTI8Q3-7UScPZDzfXA".toCharArray();
 
     @ObjectField(
-            configFieldName = KEY,
+            configFieldName = ClientConfig.KEY,
             ref = OAuthSignKeyConfig.class,
             useSubObjectDefault = true,
             description = "the key distribution sever config for sign. " +
                     "It can be different then token key distribution server."
     )
-    OAuthSignKeyConfig key;
+    @JsonProperty(ClientConfig.KEY)
+    OAuthSignKeyConfig key = null;
 
-    public String getServer_url() {
-        return server_url;
+    public String getServerUrl() {
+        return serverUrl;
     }
 
     public String getProxyHost() {
         return proxyHost;
     }
 
-    public int getProxyPort() {
+    public Integer getProxyPort() {
         return proxyPort;
     }
 
@@ -135,7 +137,7 @@ public class OauthSignConfig {
         return uri;
     }
 
-    public int getTimeout() {
+    public Integer getTimeout() {
         return timeout;
     }
 
@@ -143,12 +145,12 @@ public class OauthSignConfig {
         return enableHttp2;
     }
 
-    public char[] getClient_id() {
-        return client_id;
+    public char[] getClientId() {
+        return clientId;
     }
 
-    public char[] getClient_secret() {
-        return client_secret;
+    public char[] getClientSecret() {
+        return clientSecret;
     }
 
     public OAuthSignKeyConfig getKey() {

--- a/client-config/src/main/java/com/networknt/client/OauthTokenCacheConfig.java
+++ b/client-config/src/main/java/com/networknt/client/OauthTokenCacheConfig.java
@@ -1,18 +1,21 @@
 package com.networknt.client;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.config.schema.IntegerField;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OauthTokenCacheConfig {
 
-    public static final String CAPACITY = "capacity";
     @IntegerField(
-            configFieldName = CAPACITY,
+            configFieldName = ClientConfig.CAPACITY,
             externalizedKeyName = "tokenCacheCapacity",
             defaultValue = 200,
             description = "Capacity of caching tokens in the client for downstream API calls. The default value is 200."
     )
-    private int capacity;
+    @JsonProperty(ClientConfig.CAPACITY)
+    private Integer capacity = 200;
 
-    public int getCapacity() {
+    public Integer getCapacity() {
         return capacity;
     }
 }

--- a/client-config/src/main/java/com/networknt/client/RequestConfig.java
+++ b/client-config/src/main/java/com/networknt/client/RequestConfig.java
@@ -1,92 +1,88 @@
 package com.networknt.client;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.config.schema.BooleanField;
 import com.networknt.config.schema.IntegerField;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RequestConfig {
 
-    public static final String ERROR_THRESHOLD = "errorThreshold";
-    public static final String TIMEOUT = "timeout";
-    public static final String RESET_TIMEOUT = "resetTimeout";
-    public static final String INJECT_OPEN_TRACING = "injectOpenTracing";
-    public static final String INJECT_CALLER_ID = "injectCallerId";
-    public static final String ENABLE_HTTP_2 = "enableHttp2";
-    public static final String CONNECTION_POOL_SIZE = "connectionPoolSize";
-    public static final String CONNECTION_EXPIRE_TIME = "connectionExpireTime";
-    public static final String MAX_REQ_PER_CONN = "maxReqPerConn";
-    public static final String MAX_CONNECTION_NUM_PER_HOST = "maxConnectionNumPerHost";
-    public static final String MIN_CONNECTION_NUM_PER_HOST = "minConnectionNumPerHost";
-    public static final String MAX_REQUEST_RETRY = "maxRequestRetry";
-    public static final String REQUEST_RETRY_DELAY = "requestRetryDelay";
-
     @IntegerField(
-            configFieldName = ERROR_THRESHOLD,
-            externalizedKeyName = ERROR_THRESHOLD,
+            configFieldName = ClientConfig.ERROR_THRESHOLD,
+            externalizedKeyName = ClientConfig.ERROR_THRESHOLD,
             externalized = true,
             defaultValue = 2,
             description = "number of timeouts/errors to break the circuit"
     )
-    private int errorThreshold;
+    @JsonProperty(ClientConfig.ERROR_THRESHOLD)
+    private Integer errorThreshold = 2;
 
     @IntegerField(
-            configFieldName = TIMEOUT,
-            externalizedKeyName = TIMEOUT,
+            configFieldName = ClientConfig.TIMEOUT,
+            externalizedKeyName = ClientConfig.TIMEOUT,
             externalized = true,
             defaultValue = 3000,
             description = "timeout in millisecond to indicate a client error. " +
                     "If light-4j Http2Client is used, it is the timeout to get the\n" +
                     "connection. If http-client (JDK 11 client wrapper) is used, it is the request timeout. The default value is 3000."
     )
-    private int timeout;
+    @JsonProperty(ClientConfig.TIMEOUT)
+    private Integer timeout = 3000;
 
     @IntegerField(
-            configFieldName = RESET_TIMEOUT,
-            externalizedKeyName = RESET_TIMEOUT,
+            configFieldName = ClientConfig.RESET_TIMEOUT,
+            externalizedKeyName = ClientConfig.RESET_TIMEOUT,
             externalized = true,
             defaultValue = 7000,
             description = "reset the circuit after this timeout in millisecond"
     )
-    private int resetTimeout;
+    @JsonProperty(ClientConfig.RESET_TIMEOUT)
+    private Integer resetTimeout = 7000;
 
     @BooleanField(
-            configFieldName = INJECT_OPEN_TRACING,
-            externalizedKeyName = INJECT_OPEN_TRACING,
+            configFieldName = ClientConfig.INJECT_OPEN_TRACING,
+            externalizedKeyName = ClientConfig.INJECT_OPEN_TRACING,
             externalized = true,
             description = "if open tracing is enabled. traceability, " +
                     "correlation and metrics should not be in the chain if opentracing is used."
     )
-    private boolean injectOpenTracing;
+    @JsonProperty(ClientConfig.INJECT_OPEN_TRACING)
+    private Boolean injectOpenTracing = false;
 
     @BooleanField(
-            configFieldName = INJECT_CALLER_ID,
-            externalizedKeyName = INJECT_CALLER_ID,
+            configFieldName = ClientConfig.INJECT_CALLER_ID,
+            externalizedKeyName = ClientConfig.INJECT_CALLER_ID,
             externalized = true,
             description = "inject serviceId as callerId into the http header for metrics to collect the caller. " +
                     "The serviceId is from server.yml"
     )
-    private boolean injectCallerId;
+    @JsonProperty(ClientConfig.INJECT_CALLER_ID)
+    private Boolean injectCallerId = false;
 
     @BooleanField(
-            configFieldName = ENABLE_HTTP_2,
-            externalizedKeyName = ENABLE_HTTP_2,
+            configFieldName = ClientConfig.ENABLE_HTTP_2,
+            externalizedKeyName = ClientConfig.ENABLE_HTTP_2,
             externalized = true,
             defaultValue = true,
             description = "the flag to indicate whether http/2 is enabled when calling client.callService()"
     )
-    private boolean enableHttp2;
+    @JsonProperty(ClientConfig.ENABLE_HTTP2)
+    private Boolean enableHttp2 = true;
 
     @IntegerField(
-            configFieldName = CONNECTION_POOL_SIZE,
-            externalizedKeyName = CONNECTION_POOL_SIZE,
+            configFieldName = ClientConfig.CONNECTION_POOL_SIZE,
+            externalizedKeyName = ClientConfig.CONNECTION_POOL_SIZE,
             externalized = true,
             defaultValue = 1000,
             description = "the maximum host capacity of connection pool"
     )
-    private int connectionPoolSize;
+    @JsonProperty(ClientConfig.CONNECTION_POOL_SIZE)
+    private Integer connectionPoolSize = 1000;
 
     @IntegerField(
-            configFieldName = CONNECTION_EXPIRE_TIME,
-            externalizedKeyName = CONNECTION_EXPIRE_TIME,
+            configFieldName = ClientConfig.CONNECTION_EXPIRE_TIME,
+            externalizedKeyName = ClientConfig.CONNECTION_EXPIRE_TIME,
             externalized = true,
             defaultValue = 1800000,
             description = "Connection expire time when connection pool is used. " +
@@ -94,11 +90,12 @@ public class RequestConfig {
                     "This is one way to force the connection to be closed so that " +
                     "the client-side discovery can be balanced."
     )
-    private int connectionExpireTime;
+    @JsonProperty(ClientConfig.CONNECTION_EXPIRE_TIME)
+    private Integer connectionExpireTime = 1800000; // 30 minutes in milliseconds
 
     @IntegerField(
-            configFieldName = MAX_REQ_PER_CONN,
-            externalizedKeyName = MAX_REQ_PER_CONN,
+            configFieldName = ClientConfig.MAX_REQ_PER_CONN,
+            externalizedKeyName = ClientConfig.MAX_REQ_PER_CONN,
             externalized = true,
             defaultValue = 1000000,
             description = "The maximum request limitation for each connection in the connection pool. " +
@@ -106,20 +103,22 @@ public class RequestConfig {
                     "sending 1 million requests. " +
                     "This is one way to force the client-side discovery to re-balance the connections."
     )
-    private int maxReqPerConn;
+    @JsonProperty(ClientConfig.MAX_REQ_PER_CONN)
+    private Integer maxReqPerConn = 1000000;
 
     @IntegerField(
-            configFieldName = MAX_CONNECTION_NUM_PER_HOST,
-            externalizedKeyName = MAX_CONNECTION_NUM_PER_HOST,
+            configFieldName = ClientConfig.MAX_CONNECTION_NUM_PER_HOST,
+            externalizedKeyName = ClientConfig.MAX_CONNECTION_NUM_PER_HOST,
             externalized = true,
             defaultValue = 1000,
             description = "maximum quantity of connection in connection pool for each host"
     )
-    private int maxConnectionNumPerHost;
+    @JsonProperty(ClientConfig.MAX_CONNECTION_NUM_PER_HOST)
+    private Integer maxConnectionNumPerHost = 1000;
 
     @IntegerField(
-            configFieldName = MIN_CONNECTION_NUM_PER_HOST,
-            externalizedKeyName = MIN_CONNECTION_NUM_PER_HOST,
+            configFieldName = ClientConfig.MIN_CONNECTION_NUM_PER_HOST,
+            externalizedKeyName = ClientConfig.MIN_CONNECTION_NUM_PER_HOST,
             externalized = true,
             defaultValue = 250,
             description = "minimum quantity of connection in connection pool for each host. " +
@@ -127,80 +126,82 @@ public class RequestConfig {
                     "by remove least recently used connections when the connection number " +
                     "of a host reach 0.75 * maxConnectionNumPerHost."
     )
-    private int minConnectionNumPerHost;
+    @JsonProperty(ClientConfig.MIN_CONNECTION_NUM_PER_HOST)
+    private Integer minConnectionNumPerHost = 250;
 
     @IntegerField(
-            configFieldName = MAX_REQUEST_RETRY,
-            externalizedKeyName = MAX_REQUEST_RETRY,
+            configFieldName = ClientConfig.MAX_REQUEST_RETRY,
+            externalizedKeyName = ClientConfig.MAX_REQUEST_RETRY,
             externalized = true,
             defaultValue = 3,
             description = "Maximum request retry times for each request. If you don't want to retry, set it to 1. The default value is 3."
     )
-    private int maxRequestRetry;
+    @JsonProperty(ClientConfig.MAX_REQUEST_RETRY)
+    private Integer maxRequestRetry = 3;
 
     @IntegerField(
-            configFieldName = REQUEST_RETRY_DELAY,
-            externalizedKeyName = REQUEST_RETRY_DELAY,
+            configFieldName = ClientConfig.REQUEST_RETRY_DELAY,
+            externalizedKeyName = ClientConfig.REQUEST_RETRY_DELAY,
             externalized = true,
             defaultValue = 1000,
             description = "The delay time in milliseconds for each request retry. The default value is 1000."
     )
-    private int requestRetryDelay;
+    @JsonProperty(ClientConfig.REQUEST_RETRY_DELAY)
+    private Integer requestRetryDelay = 1000;
 
-    public int getErrorThreshold() {
+    public Integer getErrorThreshold() {
         return errorThreshold;
     }
 
-    public int getTimeout() {
+    public Integer getTimeout() {
         return timeout;
     }
 
-    public int getResetTimeout() {
+    public Integer getResetTimeout() {
         return resetTimeout;
     }
 
-    public boolean isInjectOpenTracing() {
+    public Boolean isInjectOpenTracing() {
         return injectOpenTracing;
     }
 
-    public boolean isInjectCallerId() {
+    public Boolean isInjectCallerId() {
         return injectCallerId;
     }
 
-    public boolean isEnableHttp2() {
+    public Boolean isEnableHttp2() {
         return enableHttp2;
     }
 
-
-    public void setIsEnableHttp2(boolean enableHttp2) {
+    public void setIsEnableHttp2(Boolean enableHttp2) {
         this.enableHttp2 = enableHttp2;
     }
 
-    public int getConnectionPoolSize() {
+    public Integer getConnectionPoolSize() {
         return connectionPoolSize;
     }
 
-    public int getConnectionExpireTime() {
+    public Integer getConnectionExpireTime() {
         return connectionExpireTime;
     }
 
-    public int getMaxReqPerConn() {
+    public Integer getMaxReqPerConn() {
         return maxReqPerConn;
     }
 
-    public int getMaxConnectionNumPerHost() {
+    public Integer getMaxConnectionNumPerHost() {
         return maxConnectionNumPerHost;
     }
 
-    public int getMinConnectionNumPerHost() {
+    public Integer getMinConnectionNumPerHost() {
         return minConnectionNumPerHost;
     }
 
-    public int getMaxRequestRetry() {
+    public Integer getMaxRequestRetry() {
         return maxRequestRetry;
     }
 
-    public int getRequestRetryDelay() {
+    public Integer getRequestRetryDelay() {
         return requestRetryDelay;
     }
 }

--- a/client-config/src/main/java/com/networknt/client/TlsConfig.java
+++ b/client-config/src/main/java/com/networknt/client/TlsConfig.java
@@ -1,5 +1,6 @@
 package com.networknt.client;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.config.schema.BooleanField;
 import com.networknt.config.schema.MapField;
 import com.networknt.config.schema.StringField;
@@ -9,135 +10,138 @@ import java.util.Map;
 
 public class TlsConfig {
 
-    public static final String VERIFY_HOSTNAME = "verifyHostname";
-    public static final String LOAD_DEFAULT_TRUST_STORE = "loadDefaultTrustStore";
-    public static final String LOAD_TRUST_STORE = "loadTrustStore";
-    public static final String TRUST_STORE = "trustStore";
-    public static final String TRUST_STORE_PASS = "trustStorePass";
-    public static final String LOAD_KEY_STORE = "loadKeyStore";
-    public static final String KEY_STORE = "keyStore";
-    public static final String KEY_STORE_PASS = "keyStorePass";
-    public static final String KEY_PASS = "keyPass";
-    public static final String DEFAULT_CERT_PASSWORD = "defaultCertPassword";
-    public static final String TLS_VERSION = "tlsVersion";
+
 
     @BooleanField(
-            configFieldName = VERIFY_HOSTNAME,
-            externalizedKeyName = VERIFY_HOSTNAME,
+            configFieldName = ClientConfig.VERIFY_HOSTNAME,
+            externalizedKeyName = ClientConfig.VERIFY_HOSTNAME,
             externalized = true,
             defaultValue = true,
             description = "if the server is using self-signed certificate, this need to be false. " +
                     "If true, you have to use CA signed certificate or load\n" +
                     "truststore that contains the self-signed certificate."
     )
-    private boolean verifyHostname;
+    @JsonProperty(ClientConfig.VERIFY_HOSTNAME)
+    private Boolean verifyHostname = true;
 
     @BooleanField(
-            configFieldName = LOAD_DEFAULT_TRUST_STORE,
-            externalizedKeyName = LOAD_DEFAULT_TRUST_STORE,
+            configFieldName = ClientConfig.LOAD_DEFAULT_TRUST_STORE,
+            externalizedKeyName = ClientConfig.LOAD_DEFAULT_TRUST_STORE,
             externalized = true,
             defaultValue = true,
             description = "indicate of system load default cert."
     )
-    private boolean loadDefaultTrustStore;
+    @JsonProperty(ClientConfig.LOAD_DEFAULT_TRUST_STORE)
+    private Boolean loadDefaultTrustStore = true;
 
     @BooleanField(
-            configFieldName = LOAD_TRUST_STORE,
-            externalizedKeyName = LOAD_TRUST_STORE,
+            configFieldName = ClientConfig.LOAD_TRUST_STORE,
+            externalizedKeyName = ClientConfig.LOAD_TRUST_STORE,
             externalized = true,
             defaultValue = true,
             description = "trust store contains certificates that server needs. Enable if tls is used."
     )
-    private boolean loadTrustStore;
+    @JsonProperty(ClientConfig.LOAD_TRUST_STORE)
+    private Boolean loadTrustStore = true;
 
     @StringField(
-            configFieldName = TRUST_STORE,
-            externalizedKeyName = TRUST_STORE,
+            configFieldName = ClientConfig.TRUST_STORE,
+            externalizedKeyName = ClientConfig.TRUST_STORE,
             externalized = true,
             defaultValue = "client.truststore",
             description = "trust store location can be specified here or system properties " +
                     "javax.net.ssl.trustStore and password javax.net.ssl.trustStorePassword"
     )
-    private String trustStore;
+    @JsonProperty(ClientConfig.TRUST_STORE)
+    private String trustStore = "client.truststore";
 
     @StringField(
-            configFieldName = TRUST_STORE_PASS,
-            externalizedKeyName = TRUST_STORE_PASS,
+            configFieldName = ClientConfig.TRUST_STORE_PASS,
+            externalizedKeyName = ClientConfig.TRUST_STORE_PASS,
             externalized = true,
             defaultValue = "password",
             description = "trust store password"
     )
-    private char[] trustStorePass;
+    @JsonProperty(ClientConfig.TRUST_STORE_PASS)
+    private char[] trustStorePass = "password".toCharArray();
 
     @BooleanField(
-            configFieldName = LOAD_KEY_STORE,
-            externalizedKeyName = LOAD_KEY_STORE,
+            configFieldName = ClientConfig.LOAD_KEY_STORE,
+            externalizedKeyName = ClientConfig.LOAD_KEY_STORE,
             externalized = true,
             description = "key store contains client key and it should be loaded if two-way ssl is used."
     )
-    private boolean loadKeyStore;
+    @JsonProperty(ClientConfig.LOAD_KEY_STORE)
+    private Boolean loadKeyStore;
 
     @StringField(
-            configFieldName = KEY_STORE,
-            externalizedKeyName = KEY_STORE,
+            configFieldName = ClientConfig.KEY_STORE,
+            externalizedKeyName = ClientConfig.KEY_STORE,
             externalized = true,
             defaultValue = "client.keystore",
             description = "key store location"
     )
-    private String keyStore;
+    @JsonProperty(ClientConfig.KEY_STORE)
+    private String keyStore = "client.keystore";
 
     @StringField(
-            configFieldName = KEY_STORE_PASS,
-            externalizedKeyName = KEY_STORE_PASS,
+            configFieldName = ClientConfig.KEY_STORE_PASS,
+            externalizedKeyName = ClientConfig.KEY_STORE_PASS,
             externalized = true,
             defaultValue = "password",
             description = "key store password"
     )
-    private char[] keyStorePass;
+    @JsonProperty(ClientConfig.KEY_STORE_PASS)
+    private char[] keyStorePass = "password".toCharArray();
 
     @StringField(
-            configFieldName = KEY_PASS,
-            externalizedKeyName = KEY_PASS,
+            configFieldName = ClientConfig.KEY_PASS,
+            externalizedKeyName = ClientConfig.KEY_PASS,
             externalized = true,
             defaultValue = "password",
             description = "private key password"
     )
-    private char[] keyPass;
+    @JsonProperty(ClientConfig.KEY_PASS)
+    private char[] keyPass = "password".toCharArray();
 
     @StringField(
-            configFieldName = DEFAULT_CERT_PASSWORD,
-            externalizedKeyName = DEFAULT_CERT_PASSWORD,
+            configFieldName = ClientConfig.DEFAULT_CERT_PASSWORD,
+            externalizedKeyName = ClientConfig.DEFAULT_CERT_PASSWORD,
             externalized = true,
             defaultValue = "changeit",
             description = "public issued CA cert password"
     )
-    private char[] defaultCertPassword;
+    @JsonProperty(ClientConfig.DEFAULT_CERT_PASSWORD)
+    private char[] defaultCertPassword = "changeit".toCharArray();
 
     @StringField(
-            configFieldName = TLS_VERSION,
-            externalizedKeyName = TLS_VERSION,
+            configFieldName = ClientConfig.TLS_VERSION,
+            externalizedKeyName = ClientConfig.TLS_VERSION,
             externalized = true,
             defaultValue = "TLSv1.3",
             description = "TLS version. Default is TSLv1.3, and you can downgrade to TLSv1.2 to support " +
                     "some internal old servers that support only TLSv1.1\n" +
                     "and 1.2 (deprecated and risky)."
     )
-    String tlsVersion;
+    @JsonProperty(ClientConfig.TLS_VERSION)
+    private String tlsVersion = "TLSv1.3";
 
     @StringField(
-            configFieldName = "defaultGroupKey",
-            externalizedKeyName = "defaultGroupKey",
+            configFieldName = ClientConfig.DEFAULT_GROUP_KEY,
+            externalizedKeyName = ClientConfig.DEFAULT_GROUP_KEY,
             externalized = true
     )
-    String defaultGroupKey;
+    @JsonProperty(ClientConfig.DEFAULT_GROUP_KEY)
+    private String defaultGroupKey = null;
 
     @MapField(
-            configFieldName = "trustedNames",
-            externalizedKeyName = "trustedNames",
+            configFieldName = ClientConfig.TRUSTED_NAMES,
+            externalizedKeyName = ClientConfig.TRUSTED_NAMES,
             externalized = true,
             valueType = String.class
     )
-    Map<String, String> trustedNames;
+    @JsonProperty(ClientConfig.TRUSTED_NAMES)
+    private Map<String, String> trustedNames = null;
 
     public boolean isVerifyHostname() {
         return verifyHostname;

--- a/client/src/test/java/com/networknt/client/SingleAuthServerTest.java
+++ b/client/src/test/java/com/networknt/client/SingleAuthServerTest.java
@@ -22,6 +22,6 @@ public class SingleAuthServerTest {
      */
     @Test
     public void multipleAuthServerTrue() {
-        assertFalse(config.isMultipleAuthServers());
+        assertFalse(config.getOAuth().isMultipleAuthServers());
     }
 }

--- a/egress-router/src/test/resources/config/values.yml
+++ b/egress-router/src/test/resources/config/values.yml
@@ -95,6 +95,10 @@ router.pathPrefixMaxRequestTime: "{\"/v1/address\":5000,\"/v2/address\":10000,\"
 # router.pathPrefixMaxRequestTime: {"/v1/address":5000,"/v2/address":10000,"/v3/address":30000,"/v1/pets/{petId}": 5000}
 
 # client.yml
+client.tokenRenewBeforeExpired: 30000
+client.expiredRefreshRetryDelay: 1000
+client.earlyRefreshRetryDelay: 1000
+
 # test configuration for the TokenHandler with multiple OAuth 2.0 providers.
 client.multipleAuthServers: true
 client.tokenCcServiceIdAuthServers:

--- a/header/src/main/java/com/networknt/header/HeaderHandler.java
+++ b/header/src/main/java/com/networknt/header/HeaderHandler.java
@@ -133,13 +133,13 @@ public class HeaderHandler implements MiddlewareHandler {
                         }
                     }
 
-                    // Add response header manipulation after the response is ready to send back.
-                    exchange.addResponseWrapper(new ConduitWrapper<>() {
-                        final HeaderResponseConfig responseHeaderMap = pathPrefixConfig.getResponse();
-                        @Override
-                        public StreamSinkConduit wrap(ConduitFactory<StreamSinkConduit> factory, HttpServerExchange responseExchange) {
-                            if (responseHeaderMap != null) {
+                    if (pathPrefixConfig.getResponse() != null) {
 
+                        // Add response header manipulation after the response is ready to send back.
+                        exchange.addResponseWrapper(new ConduitWrapper<>() {
+                            final HeaderResponseConfig responseHeaderMap = pathPrefixConfig.getResponse();
+                            @Override
+                            public StreamSinkConduit wrap(ConduitFactory<StreamSinkConduit> factory, HttpServerExchange responseExchange) {
                                 List<String> responseHeaderRemoveList = responseHeaderMap.getRemove();
                                 if (responseHeaderRemoveList != null) {
                                     responseHeaderRemoveList.forEach(s -> {
@@ -155,11 +155,13 @@ public class HeaderHandler implements MiddlewareHandler {
                                         logger.trace("update response header {} with value {}", k, v);
                                     });
                                 }
+                                return factory.create();
                             }
+                        });
 
-                            return factory.create();
-                        }
-                    });
+                    }
+
+
                 }
             }
         }


### PR DESCRIPTION
- Fixed issue with default settings in the `TokenHandler`
- Added unit tests for multi-auth configuration. 
- Modifed `ClientConfig` to allow null values for `proxyPort`, 
- Changed fieldnames from `snake case` --> `camel case`.
- Updated `HeaderHandler` to not attach conduit if response options are null.