### PR TITLE
Fix For Multi Threaded Config Load Race Condition

### DIFF
--- a/config/src/main/java/com/networknt/config/Config.java
+++ b/config/src/main/java/com/networknt/config/Config.java
@@ -449,14 +449,16 @@ public abstract class Config {
             Map<String, Object> config = null;
             String ymlFilename = configName + fileExtension;
             try (InputStream inStream = getConfigStream(ymlFilename, path)) {
-                if (inStream != null) {
-                    config = getYaml().load(inStream);
+                if (inStream != null && inStream.available() > 0) {
+                    synchronized (getYaml()) {
+                        config = getYaml().load(inStream);
+                    }
                     if (!ConfigInjection.isExclusionConfigFile(configName)) {
                         CentralizedManagement.mergeMap(isDecrypt(), config); // mutates the config map in place.
                     }
                 }
             } catch (Exception e) {
-                logger.error("Exception on loading " + ymlFilename, e);
+                logger.error("Exception on loading {}", ymlFilename, e);
                 throw new RuntimeException("Unable to load " + ymlFilename + " as map.", e);
             }
             return config;

--- a/config/src/main/java/com/networknt/config/schema/generator/JsonSchemaGenerator.java
+++ b/config/src/main/java/com/networknt/config/schema/generator/JsonSchemaGenerator.java
@@ -229,13 +229,10 @@ public class JsonSchemaGenerator extends Generator {
         } else if (Generator.fieldIsSubMap(field, MetadataParser.PROPERTIES_KEY)) {
             objectProperties = (LinkedHashMap<String, Object>) field.get(MetadataParser.PROPERTIES_KEY);
 
-        // TODO - handle anyOf, oneOf, allOf, not etc.
-        } else {
-            throw new IllegalArgumentException("Object field must contain a reference or additional properties.");
-        }
+        } else return; // No properties to parse, return early.
+
 
         /* special handling for json default value */
-        // TODO - handle useSubObjectDefault for object
         final var presentValue = AnnotationUtils.getAsType(field.get(MetadataParser.DEFAULT_VALUE_KEY), String.class);
         if (presentValue != null && !Objects.equals(presentValue, ConfigSchema.DEFAULT_STRING)) {
             try {


### PR DESCRIPTION
- Fixed an issue where non-cached config would result in race conditions on reloads/restarts when trying to load the config file.
- Fixed an issue with JsonSchemaGenerator failing on MapFields with Object.class as the value type.