### PR TITLE
00felix: chore: upgrade ch.qos.logback:logback-core to 1.5.18

### DIFF
--- a/config-reload/pom.xml
+++ b/config-reload/pom.xml
@@ -65,6 +65,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <version>1.5.21</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/logger-handler/pom.xml
+++ b/logger-handler/pom.xml
@@ -62,6 +62,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <version>1.5.21</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.5.21</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <version.jose4j>0.9.6</version.jose4j>
         <version.commons.codec>1.18.0</version.commons.codec>
         <version.encoder>1.3.1</version.encoder>
-        <version.logback>1.5.18</version.logback>
+        <version.logback>1.5.21</version.logback>
         <version.junit>4.13.2</version.junit>
         <version.mockito>3.11.1</version.mockito>
         <version.powermock>2.0.9</version.powermock>

--- a/sidecar/pom.xml
+++ b/sidecar/pom.xml
@@ -74,6 +74,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <version>1.5.21</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.5.21</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>


### PR DESCRIPTION
**Upgrade `ch.qos.logback:logback-core` from `1.5.18` to `1.5.21`**

This pull request upgrades `ch.qos.logback:logback-core` from version `1.5.18` to `1.5.21` to address multiple security vulnerabilities and ensure compliance with security best practices. The upgrade has been tested locally to confirm compatibility with existing functionality.
Vulnerabilities Addressed

| Vulnerability | Description |
| --- | --- |

This upgrade enhances the security and stability of the `ch.qos.logback:logback-core` dependency.