### PR TITLE
close BufferedReader in code

### DIFF
--- a/logger-handler/src/main/java/com/networknt/logging/handler/LoggerGetLogContentsHandler.java
+++ b/logger-handler/src/main/java/com/networknt/logging/handler/LoggerGetLogContentsHandler.java
@@ -109,8 +109,9 @@ public class LoggerGetLogContentsHandler implements LightHttpHandler {
             Appender<ILoggingEvent> logEvent = it.next();
             if(logEvent.getClass().equals(RollingFileAppender.class)) {
                 FileReader reader = new FileReader(((RollingFileAppender<ILoggingEvent>) logEvent).getFile());
-                BufferedReader bufferedReader = new BufferedReader(reader);
-                res = this.parseAppenderFile(bufferedReader, startTime, endTime, log, loggerLevel, offset, limit);
+                try (BufferedReader bufferedReader = new BufferedReader(reader)) {
+                    res = this.parseAppenderFile(bufferedReader, startTime, endTime, log, loggerLevel, offset, limit);
+                }
             }
         }
         return res;


### PR DESCRIPTION
Came across this in logger-handler/src/main/java/com/networknt/logging/handler/LoggerGetLogContentsHandler.java while following the call chain — The resource opened there can leak if code exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Feel free to close if not relevant.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.